### PR TITLE
perf(worker) optimize worker queue

### DIFF
--- a/lualib/resty/events/broker.lua
+++ b/lualib/resty/events/broker.lua
@@ -28,7 +28,9 @@ local cjson_encode = cjson.encode
 local MAX_UNIQUE_EVENTS = 1024
 
 local function is_closed(err)
-    return err and str_sub(err, -6) == "closed"
+    return err and
+           (str_sub(err, -6) == "closed" or
+            str_sub(err, -11) == "broken pipe")
 end
 
 local _M = {

--- a/lualib/resty/events/broker.lua
+++ b/lualib/resty/events/broker.lua
@@ -96,7 +96,7 @@ function _M:run()
 
             d, err = decode(data)
             if not d then
-                log(ERR, "worker-events: failed decoding event data: ", err)
+                log(ERR, "failed to decode event data: ", err)
                 goto continue
             end
 

--- a/lualib/resty/events/broker.lua
+++ b/lualib/resty/events/broker.lua
@@ -1,3 +1,4 @@
+local cjson = require "cjson.safe"
 local codec = require "resty.events.codec"
 local lrucache = require "resty.lrucache"
 
@@ -21,6 +22,8 @@ local kill = ngx.thread.kill
 local wait = ngx.thread.wait
 
 local decode = codec.decode
+
+local cjson_encode = cjson.encode
 
 local MAX_UNIQUE_EVENTS = 1024
 
@@ -117,7 +120,8 @@ function _M:run()
                 local ok, err = q:push(d.data)
 
                 if not ok then
-                    log(ERR, "failed to publish event: ", err)
+                    log(ERR, "failed to publish event: ", err, ". ",
+                             "data is :", cjson_encode(decode(d.data)))
 
                 else
                     n = n + 1

--- a/lualib/resty/events/init.lua
+++ b/lualib/resty/events/init.lua
@@ -13,7 +13,7 @@ local str_sub = string.sub
 local worker_count = ngx.worker.count()
 
 local _M = {
-    _VERSION = '0.1.1',
+    _VERSION = '0.1.2',
 }
 local _MT = { __index = _M, }
 

--- a/lualib/resty/events/worker.lua
+++ b/lualib/resty/events/worker.lua
@@ -149,7 +149,7 @@ function _M:communicate(premature)
 
             local d, err = decode(data)
             if not d then
-                return nil, "worker-events: failed decoding event data: " .. err
+                return nil, "failed to decode event data: " .. err
             end
 
             -- got an event data, push to queue, callback in events_thread

--- a/lualib/resty/events/worker.lua
+++ b/lualib/resty/events/worker.lua
@@ -186,7 +186,7 @@ function _M:communicate(premature)
         end -- while not exiting
     end)  -- write_thread
 
-    local current_thread = spawn(function()
+    local events_thread = spawn(function()
         while not exiting() do
             local data, err = self._sub_queue:pop()
 
@@ -208,13 +208,13 @@ function _M:communicate(premature)
 
             ::continue::
         end -- while not exiting
-    end)  -- current_thread
+    end)  -- events_thread
 
-    local ok, err, perr = wait(write_thread, read_thread, current_thread)
+    local ok, err, perr = wait(write_thread, read_thread, events_thread)
 
     kill(write_thread)
     kill(read_thread)
-    kill(current_thread)
+    kill(events_thread)
 
     self._connected = nil
 

--- a/lualib/resty/events/worker.lua
+++ b/lualib/resty/events/worker.lua
@@ -152,8 +152,11 @@ function _M:communicate(premature)
                 return nil, "worker-events: failed decoding event data: " .. err
             end
 
-            -- got an event data, callback
-            do_event(self, d)
+            -- got an event data, push to queue, callback in events_thread
+            local ok, err = self._sub_queue:push(d)
+            if not ok then
+                log(ERR, "failed to store event: ", err)
+            end
 
             ::continue::
         end -- while not exiting

--- a/lualib/resty/events/worker.lua
+++ b/lualib/resty/events/worker.lua
@@ -1,3 +1,4 @@
+local cjson = require "cjson.safe"
 local codec = require "resty.events.codec"
 local que = require "resty.events.queue"
 local callback = require "resty.events.callback"
@@ -24,6 +25,7 @@ local timer_at = ngx.timer.at
 
 local encode = codec.encode
 local decode = codec.decode
+local cjson_encode = cjson.encode
 
 local EMPTY_T = {}
 
@@ -155,7 +157,8 @@ function _M:communicate(premature)
             -- got an event data, push to queue, callback in events_thread
             local ok, err = self._sub_queue:push(d)
             if not ok then
-                log(ERR, "failed to store event: ", err)
+                log(ERR, "failed to store event: ", err, ". ",
+                         "data is :", cjson_encode(d))
             end
 
             ::continue::

--- a/lualib/resty/events/worker.lua
+++ b/lualib/resty/events/worker.lua
@@ -13,6 +13,7 @@ local random = math.random
 
 local ngx = ngx
 local log = ngx.log
+local sleep = ngx.sleep
 local exiting = ngx.worker.exiting
 local ERR = ngx.ERR
 local DEBUG = ngx.DEBUG
@@ -211,6 +212,9 @@ function _M:communicate(premature)
 
             -- got an event data, callback
             do_event(self, data)
+
+            -- yield, not block other threads
+            sleep(0)
 
             ::continue::
         end -- while not exiting


### PR DESCRIPTION
When we receive an event from the broker, 
we do not process it immediately but push it to a queue.
by this action, we can avoid the block of callback function and
handle more incoming events.
