### PR TITLE
feat(worker) worker send events rate limiting

### DIFF
--- a/lualib/resty/events/protocol.lua
+++ b/lualib/resty/events/protocol.lua
@@ -16,7 +16,8 @@ local type = type
 local str_sub = string.sub
 local setmetatable = setmetatable
 
-local DEFAULT_TIMEOUT = 1000     -- 1000ms
+-- for high traffic pressure
+local DEFAULT_TIMEOUT = 5000     -- 5000ms
 
 local function is_timeout(err)
     return err and str_sub(err, -7) == "timeout"

--- a/lualib/resty/events/queue.lua
+++ b/lualib/resty/events/queue.lua
@@ -10,13 +10,12 @@ local math_min = math.min
 local _M = {}
 local _MT = { __index = _M, }
 
-local DEFAULT_MAX_QUEUE_LEN = 1024 * 10
 local DEFAULT_QUEUE_LEN = 4096
 
 function _M.new(max_len)
     local self = {
         semaphore = assert(semaphore.new()),
-        max = max_len or DEFAULT_MAX_QUEUE_LEN,
+        max = max_len,
 
         elts = table_new(math_min(max_len, DEFAULT_QUEUE_LEN), 0),
         first = 0,


### PR DESCRIPTION
If the worker sends too many events in a short time,
then the broker will not process them properly, 
it will get timeout or send/receive error.

This PR add a simple rate-limiting feature in the worker's write_thread,
Now the rate-limiting is 100/50ms (2000/s), I think it is enough for us.