### PR TITLE
feat(broker) forward unique event to a random worker

### DIFF
--- a/lualib/resty/events/broker.lua
+++ b/lualib/resty/events/broker.lua
@@ -1,4 +1,5 @@
 local cjson = require "cjson.safe"
+local nkeys = require "table.nkeys"
 local codec = require "resty.events.codec"
 local lrucache = require "resty.lrucache"
 
@@ -39,7 +40,7 @@ local function broadcast_events(self, unique, data)
     local n = 0
 
     -- if unique, schedule to a random worker
-    local idx = unique and random(1, #self._clients)
+    local idx = unique and random(1, nkeys(self._clients))
 
     for _, q in pairs(self._clients) do
         local ok, err

--- a/lualib/resty/events/broker.lua
+++ b/lualib/resty/events/broker.lua
@@ -43,7 +43,6 @@ local function broadcast_events(self, unique, data)
     local idx = unique and random(1, nkeys(self._clients))
 
     for _, q in pairs(self._clients) do
-        local ok, err
 
         -- skip some and broadcast to one workers
         if unique then
@@ -54,7 +53,7 @@ local function broadcast_events(self, unique, data)
             end
         end
 
-        ok, err = q:push(data)
+        local ok, err = q:push(data)
 
         if not ok then
             log(ERR, "failed to publish event: ", err, ". ",

--- a/lualib/resty/events/broker.lua
+++ b/lualib/resty/events/broker.lua
@@ -74,7 +74,7 @@ local function broadcast_events(self, unique, data)
 end
 
 local _M = {
-    _VERSION = '0.1.2',
+    _VERSION = '0.1.3',
 }
 local _MT = { __index = _M, }
 

--- a/lualib/resty/events/broker.lua
+++ b/lualib/resty/events/broker.lua
@@ -52,13 +52,9 @@ local function broadcast_events(self, unique, data)
             if idx > 0 then
                 goto continue
             end
-
-            ok, err = q:push(data)
-
-        -- broadcast to all workers
-        else
-            ok, err = q:push(data)
         end
+
+        ok, err = q:push(data)
 
         if not ok then
             log(ERR, "failed to publish event: ", err, ". ",

--- a/lualib/resty/events/init.lua
+++ b/lualib/resty/events/init.lua
@@ -13,7 +13,7 @@ local str_sub = string.sub
 local worker_count = ngx.worker.count()
 
 local _M = {
-    _VERSION = '0.1.2',
+    _VERSION = '0.1.3',
 }
 local _MT = { __index = _M, }
 


### PR DESCRIPTION
In the old code, we always forward the 'unique' event to the first worker in the hash table.
It may case that worker too busy.

This PR adds a random choice to forward 'unique' events, reduce the cpu pressure of one worker.