### PR TITLE
chore(compat): new api native() in compat mode

### DIFF
--- a/lualib/resty/events/compat/init.lua
+++ b/lualib/resty/events/compat/init.lua
@@ -14,8 +14,12 @@ local handlers = {}
 local _configured
 
 local _M = {
-    _VERSION = '0.1.0',
+    _VERSION = '0.1.1',
 }
+
+function _M.navive()
+    return ev
+end
 
 function _M.poll()
     sleep(0.002) -- wait events sync by unix socket connect

--- a/lualib/resty/events/compat/init.lua
+++ b/lualib/resty/events/compat/init.lua
@@ -17,7 +17,7 @@ local _M = {
     _VERSION = '0.1.1',
 }
 
-function _M.navive()
+function _M.native()
     return ev
 end
 

--- a/lualib/resty/events/init.lua
+++ b/lualib/resty/events/init.lua
@@ -13,7 +13,7 @@ local str_sub = string.sub
 local worker_count = ngx.worker.count()
 
 local _M = {
-    _VERSION = '0.1.3',
+    _VERSION = '0.1.4',
 }
 local _MT = { __index = _M, }
 


### PR DESCRIPTION
Introduce an API `native()` for compatible mode, 
we can get the native events object by this function, 
then use new APIs.