### PR TITLE
fix(worker/broker): events thread was killed prematurely

### DIFF
--- a/lualib/resty/events/broker.lua
+++ b/lualib/resty/events/broker.lua
@@ -1,16 +1,13 @@
 local cjson = require "cjson.safe"
-local nkeys = require "table.nkeys"
 local codec = require "resty.events.codec"
 local lrucache = require "resty.lrucache"
-
-local que = require "resty.events.queue"
+local queue = require "resty.events.queue"
 local server = require("resty.events.protocol").server
 local is_timeout = server.is_timeout
+local is_closed = server.is_closed
 
 local pairs = pairs
 local setmetatable = setmetatable
-local str_sub = string.sub
-local random = math.random
 
 local ngx = ngx
 local log = ngx.log
@@ -28,37 +25,44 @@ local decode = codec.decode
 local cjson_encode = cjson.encode
 
 local MAX_UNIQUE_EVENTS = 1024
+local WEAK_KEYS_MT = { __mode = "k", }
 
-local function is_closed(err)
-    return err and
-           (str_sub(err, -6) == "closed" or
-            str_sub(err, -11) == "broken pipe")
+local function terminating(self, worker_connection)
+    return self._clients[worker_connection] == nil or exiting()
+end
+
+local function get_event_data(self, event_data)
+    local unique = event_data.spec.unique
+    if unique then
+        local uniques = self._uniques
+        if uniques:get(unique) then
+            if not exiting() then
+                log(DEBUG, "unique event is duplicate: ", unique)
+            end
+
+            return
+        end
+
+        uniques:set(unique, 1, self._opts.unique_timeout)
+    end
+    return event_data.data, unique
 end
 
 -- broadcast to all/unique workers
-local function broadcast_events(self, unique, data)
+local function broadcast_events(self, event_data)
+    local data, unique = get_event_data(self, event_data)
+    if not data then
+        return
+    end
+
     local n = 0
 
-    -- if unique, schedule to a random worker
-    local idx = unique and random(1, nkeys(self._clients))
-
-    for _, q in pairs(self._clients) do
-
-        -- skip some and broadcast to one workers
-        if unique then
-            idx = idx - 1
-
-            if idx > 0 then
-                goto continue
-            end
-        end
-
-        local ok, err = q:push(data)
-
-        if not ok then
+    -- pairs is "random" enough for unique
+    for _, client_queue in pairs(self._clients) do
+        local _, err = client_queue:push(data)
+        if err then
             log(ERR, "failed to publish event: ", err, ". ",
                      "data is :", cjson_encode(decode(data)))
-
         else
             n = n + 1
 
@@ -66,26 +70,80 @@ local function broadcast_events(self, unique, data)
                 break
             end
         end
-
-        ::continue::
-    end  -- for q in pairs(_clients)
+    end
 
     log(DEBUG, "event published to ", n, " workers")
+end
+
+local function read_thread(self, worker_connection)
+    while not terminating(self, worker_connection) do
+        local data, err = worker_connection:recv_frame()
+        if err then
+            if not is_timeout(err) then
+                return nil, "failed to read event from worker: " .. err
+            end
+
+            -- timeout
+            goto continue
+        end
+
+        if not data then
+            if not exiting() then
+                log(ERR, "did not receive event from worker")
+            end
+            goto continue
+        end
+
+        local event_data, err = decode(data)
+        if not event_data then
+            if not exiting() then
+                log(ERR, "failed to decode event data: ", err)
+            end
+            goto continue
+        end
+
+        broadcast_events(self, event_data)
+
+        ::continue::
+    end -- while not exiting
+
+    return true
+end
+
+local function write_thread(self, worker_connection)
+    while not terminating(self, worker_connection) do
+        local payload, err = self._clients[worker_connection]:pop()
+        if not payload then
+            if not is_timeout(err) then
+                return nil, "semaphore wait error: " .. err
+            end
+
+            goto continue
+        end
+
+        local _, err = worker_connection:send_frame(payload)
+        if err then
+            return nil, "failed to send event: " .. err
+        end
+
+        ::continue::
+    end -- while not exiting
+
+    return true
 end
 
 local _M = {
     _VERSION = '0.1.3',
 }
+
 local _MT = { __index = _M, }
 
 function _M.new(opts)
-    local self = {
+    return setmetatable({
         _opts = opts,
         _uniques = nil,
         _clients = nil,
-    }
-
-    return setmetatable(self, _MT)
+    }, _MT)
 end
 
 function _M:init()
@@ -96,108 +154,33 @@ function _M:init()
         return nil, "failed to create the events cache: " .. (err or "unknown")
     end
 
-    local _clients = setmetatable({}, { __mode = "k", })
-
     self._uniques = _uniques
-    self._clients = _clients
+    self._clients = setmetatable({}, WEAK_KEYS_MT)
 
     return true
 end
 
 function _M:run()
-    local conn, err = server:new()
-
-    if not conn then
+    local worker_connection, err = server.new()
+    if not worker_connection then
         log(ERR, "failed to init socket: ", err)
         exit(444)
     end
 
-    local queue = que.new(self._opts.max_queue_len)
+    self._clients[worker_connection] = queue.new(self._opts.max_queue_len)
 
-    self._clients[conn] = queue
+    local read_thread_co = spawn(read_thread, self, worker_connection)
+    local write_thread_co = spawn(write_thread, self, worker_connection)
 
-    local read_thread = spawn(function()
-        while not exiting() do
-            local data, err = conn:recv_frame()
+    local ok, err, perr = wait(read_thread_co, write_thread_co)
 
-            if exiting() then
-                return
-            end
+    self._clients[worker_connection] = nil
 
-            if err then
-                if not is_timeout(err) then
-                  return nil, err
-                end
-
-                -- timeout
-                goto continue
-            end
-
-            if not data then
-                return nil, "did not receive event from worker"
-            end
-
-            local d, err
-
-            d, err = decode(data)
-            if not d then
-                log(ERR, "failed to decode event data: ", err)
-                goto continue
-            end
-
-            -- unique event
-            local unique = d.spec.unique
-            if unique then
-                if self._uniques:get(unique) then
-                    log(DEBUG, "unique event is duplicate: ", unique)
-                    goto continue
-                end
-
-                self._uniques:set(unique, 1, self._opts.unique_timeout)
-            end
-
-            -- broadcast to all/unique workers
-            broadcast_events(self, unique, d.data)
-
-            ::continue::
-        end -- while not exiting
-    end)  -- read_thread
-
-    local write_thread = spawn(function()
-        while not exiting() do
-            local payload, err = queue:pop()
-
-            if not payload then
-                if not is_timeout(err) then
-                    return nil, "semaphore wait error: " .. err
-                end
-
-                goto continue
-            end
-
-            if exiting() then
-                return
-            end
-
-            local _, err = conn:send_frame(payload)
-            if err then
-                log(ERR, "failed to send event: ", err)
-            end
-
-            if is_closed(err) then
-                return
-            end
-
-            ::continue::
-        end -- while not exiting
-    end)  -- write_thread
-
-    local ok, err, perr = wait(write_thread, read_thread)
-
-    self._clients[conn] = nil
-
-    kill(write_thread)
-    kill(read_thread)
+    if exiting() then
+        kill(read_thread_co)
+        kill(write_thread_co)
+        return
+    end
 
     if not ok and not is_closed(err) then
         log(ERR, "event broker failed: ", err)
@@ -209,8 +192,10 @@ function _M:run()
         return exit(ngx.ERROR)
     end
 
+    wait(read_thread_co)
+    wait(write_thread_co)
+
     return exit(ngx.OK)
 end
 
 return _M
-

--- a/lualib/resty/events/queue.lua
+++ b/lualib/resty/events/queue.lua
@@ -1,6 +1,6 @@
 local semaphore = require "ngx.semaphore"
-
 local table_new = require "table.new"
+
 
 local assert = assert
 local setmetatable = setmetatable
@@ -10,14 +10,16 @@ local math_min = math.min
 local _M = {}
 local _MT = { __index = _M, }
 
-local DEFAULT_QUEUE_LEN = 4096
+
+local MAX_QUEUE_PREALLOCATE = 4096
+
 
 function _M.new(max_len)
     local self = {
         semaphore = assert(semaphore.new()),
         max = max_len,
 
-        elts = table_new(math_min(max_len, DEFAULT_QUEUE_LEN), 0),
+        elts = table_new(math_min(max_len, MAX_QUEUE_PREALLOCATE), 0),
         first = 0,
         last = -1,
     }
@@ -28,7 +30,6 @@ end
 
 function _M:push(item)
     local last = self.last
-
     if last - self.first + 1 >= self.max then
         return nil, "queue overflow"
     end
@@ -50,7 +51,6 @@ function _M:pop()
     end
 
     local first = self.first
-
     if first > self.last then
         return nil, "queue is empty"
     end
@@ -58,7 +58,6 @@ function _M:pop()
     local item = self.elts[first]
     self.elts[first] = nil
     self.first = first + 1
-
     return item
 end
 

--- a/t/broadcast.t
+++ b/t/broadcast.t
@@ -7,7 +7,7 @@ use Test::Nginx::Socket::Lua;
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 7) + 2;
+plan tests => repeat_each() * (blocks() * 14) + 2;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
@@ -18,7 +18,6 @@ workers(4);
 run_tests();
 
 __DATA__
-
 
 === TEST 1: posting events and handling events, broadcast
 --- http_config
@@ -39,10 +38,13 @@ __DATA__
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
         end
 
+        local i = 0
+
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
-                    ", data=", data)
-                end)
+            i = i + 1
+            ngx.log(ngx.DEBUG, i, " worker-events: handler event; source=", source, ", event=", event,
+                               ", wid=", wid, ", by=", ngx.worker.id(), ", data=", data)
+        end)
 
         _G.ev = ev
     }
@@ -69,22 +71,25 @@ __DATA__
 GET /test
 --- response_body
 ok
---- error_log
-event published to 4 workers
+--- error_log eval
+[
+    qr/event published to 4 workers/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=0, data=01234567890/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=1, data=01234567890/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=2, data=01234567890/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=3, data=01234567890/
+]
 --- no_error_log
 [error]
 [crit]
 [alert]
---- grep_error_log eval: qr/worker-events: .*/
+--- grep_error_log eval: qr/worker-events: handling event; .*/
 --- grep_error_log_out eval
 qr/^worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890$/
+worker-events: handling event; source=content_by_lua, event=request1, wid=\d+$/
+
 
 
 === TEST 2: posting events and handling events, local
@@ -106,10 +111,18 @@ worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, d
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
         end
 
+        local i = 0
+
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=", source,", event=", event, ", wid=", wid,
-                    ", data=", data)
-                end)
+            if wid then
+                i = 3
+            else
+                i = i + 1
+            end
+
+            ngx.log(ngx.DEBUG, i, " worker-events: handler event; source=", source, ", event=", event,
+                               ", wid=", wid, ", by=", ngx.worker.id(), ", data=", data)
+        end)
 
         _G.ev = ev
     }
@@ -127,9 +140,10 @@ worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, d
         content_by_lua_block {
             local ev = _G.ev
 
-            ev:publish("current", "content_by_lua","request1","01234567890")
-            ev:publish("current", "content_by_lua","request2","01234567890")
-            ev:publish("all", "content_by_lua","request3","01234567890")
+            ev:publish("current", "content_by_lua", "request1", "ABCDEFGHIJK")
+            ev:publish("current", "content_by_lua", "request2", "LMNOPQRSTUV")
+            ngx.sleep(0.05)
+            ev:publish("all", "content_by_lua", "request3", "01234567890")
 
             ngx.say("ok")
         }
@@ -138,26 +152,29 @@ worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, d
 GET /test
 --- response_body
 ok
---- error_log
-event published to 4 workers
+--- error_log eval
+[
+    qr/event published to 4 workers/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=nil, by=\d+, data=ABCDEFGHIJK/,
+    qr/2 worker-events: handler event; source=content_by_lua, event=request2, wid=nil, by=\d+, data=LMNOPQRSTUV/,
+    qr/3 worker-events: handler event; source=content_by_lua, event=request3, wid=\d+, by=0, data=01234567890/,
+    qr/3 worker-events: handler event; source=content_by_lua, event=request3, wid=\d+, by=1, data=01234567890/,
+    qr/3 worker-events: handler event; source=content_by_lua, event=request3, wid=\d+, by=2, data=01234567890/,
+    qr/3 worker-events: handler event; source=content_by_lua, event=request3, wid=\d+, by=3, data=01234567890/
+]
 --- no_error_log
 [error]
 [crit]
 [alert]
---- grep_error_log eval: qr/worker-events: .*/
+--- grep_error_log eval: qr/worker-events: handling event; .*/
 --- grep_error_log_out eval
 qr/^worker-events: handling event; source=content_by_lua, event=request1, wid=nil
-worker-events: handler event;  source=content_by_lua, event=request1, wid=nil, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request2, wid=nil
-worker-events: handler event;  source=content_by_lua, event=request2, wid=nil, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890
-worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890$/
+worker-events: handling event; source=content_by_lua, event=request3, wid=\d+$/
+
 
 
 === TEST 3: worker.events 'one' being done, and only once
@@ -181,9 +198,9 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
         end
 
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=", source, ", event=", event, ", wid=", wid,
-                    ", data=", tostring(data))
-                end)
+            ngx.log(ngx.DEBUG, "worker-events: handler event; source=", source, ", event=", event,
+                               ", wid=", wid, ", by=", ngx.worker.id(), ", data=", data)
+        end)
 
         _G.ev = ev
     }
@@ -201,21 +218,17 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
         content_by_lua_block {
             local ev = _G.ev
 
-            ev:publish("all", "content_by_lua","request1","01234567890")
+            ev:publish("all", "content_by_lua", "request1", "01234567890")
 
-            ngx.sleep(0.05) -- wait for logs
-
-            ev:publish("unique_value", "content_by_lua", "request2", "01234567890")
-            ev:publish("unique_value", "content_by_lua", "request3", "01234567890")
+            ev:publish("unique_value", "content_by_lua", "request2", "ABCDEFGHIJK")
+            ev:publish("unique_value", "content_by_lua", "request3", "LMNOPQRSTUV")
 
             ngx.sleep(0.1) -- wait for unique timeout to expire
 
-            ev:publish("unique_value", "content_by_lua", "request4", "01234567890")
-            ev:publish("unique_value", "content_by_lua", "request5", "01234567890")
+            ev:publish("unique_value", "content_by_lua", "request4", "WXYZABCDEFG")
+            ev:publish("unique_value", "content_by_lua", "request5", "HIJKLMNOPQR")
 
-            ngx.sleep(0.05) -- wait for logs
-
-            ev:publish("all", "content_by_lua", "request6", "01234567890")
+            ev:publish("all", "content_by_lua", "request6", "STUVWXYZABC")
 
             ngx.say("ok")
         }
@@ -224,26 +237,25 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 GET /test
 --- response_body
 ok
---- error_log
-event published to 1 workers
-unique event is duplicate: unique_value
-event published to 4 workers
+--- error_log eval
+[
+    qr/event published to 1 workers/,
+    qr/unique event is duplicate: unique_value/,
+    qr/event published to 4 workers/,
+    qr/worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=0, data=01234567890/,
+    qr/worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=1, data=01234567890/,
+    qr/worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=2, data=01234567890/,
+    qr/worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=3, data=01234567890/,
+    qr/worker-events: handler event; source=content_by_lua, event=request2, wid=\d+, by=\d+, data=ABCDEFGHIJK/,
+    qr/worker-events: handler event; source=content_by_lua, event=request4, wid=\d+, by=\d+, data=WXYZABCDEFG/,
+    qr/worker-events: handler event; source=content_by_lua, event=request6, wid=\d+, by=0, data=STUVWXYZABC/,
+    qr/worker-events: handler event; source=content_by_lua, event=request6, wid=\d+, by=1, data=STUVWXYZABC/,
+    qr/worker-events: handler event; source=content_by_lua, event=request6, wid=\d+, by=2, data=STUVWXYZABC/,
+    qr/worker-events: handler event; source=content_by_lua, event=request6, wid=\d+, by=3, data=STUVWXYZABC/
+]
 --- no_error_log
 [error]
 [crit]
 [alert]
---- grep_error_log eval: qr/worker-events: handler .*/
---- grep_error_log_out eval
-qr/^worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request2, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request4, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890$/
-
-
-
+LMNOPQRSTUV
+HIJKLMNOPQR

--- a/t/callback.t
+++ b/t/callback.t
@@ -19,7 +19,7 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: registering and unsubscribeing event handlers at different levels
+=== TEST 1: registering and unsubscribing event handlers at different levels
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 --- config
@@ -29,7 +29,7 @@ __DATA__
 
             local wid = ngx.worker.id()
             local cb = function(extra, data, event, source, wid)
-                ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+                ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                         ", data=", data, ", callback=",extra)
             end
 
@@ -48,36 +48,36 @@ __DATA__
                 ec:do_event({source = s, event = e, data = d, wid = wid})
             end
 
-            post("content_by_lua","request1","123")
-            post("content_by_lua","request2","123")
-            post("content_by_lua","request3","123")
+            post("content_by_lua", "request1", "123")
+            post("content_by_lua", "request2", "123")
+            post("content_by_lua", "request3", "123")
 
             --ec.unsubscribe("*", "*")
             ec:unsubscribe(id1)
 
-            post("content_by_lua","request1","124")
-            post("content_by_lua","request2","124")
-            post("content_by_lua","request3","124")
+            post("content_by_lua", "request1", "124")
+            post("content_by_lua", "request2", "124")
+            post("content_by_lua", "request3", "124")
 
             --ec:unsubscribe("content_by_lua", "*")
             ec:unsubscribe(id2)
 
-            post("content_by_lua","request1","125")
-            post("content_by_lua","request2","125")
-            post("content_by_lua","request3","125")
+            post("content_by_lua", "request1", "125")
+            post("content_by_lua", "request2", "125")
+            post("content_by_lua", "request3", "125")
 
             ec:unsubscribe(id3)
             ec:unsubscribe(id4)
 
-            post("content_by_lua","request1","126")
-            post("content_by_lua","request2","126")
-            post("content_by_lua","request3","126")
+            post("content_by_lua", "request1", "126")
+            post("content_by_lua", "request2", "126")
+            post("content_by_lua", "request3", "126")
 
             ec:unsubscribe(id5)
 
-            post("content_by_lua","request1","127")
-            post("content_by_lua","request2","127")
-            post("content_by_lua","request3","127")
+            post("content_by_lua", "request1", "127")
+            post("content_by_lua", "request2", "127")
+            post("content_by_lua", "request3", "127")
 
             ngx.say("ok")
         }
@@ -128,6 +128,7 @@ worker-events: handling event; source=content_by_lua, event=request2, wid=\d+
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+$/
 
 
+
 === TEST 2: callback error handling
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
@@ -150,7 +151,7 @@ worker-events: handling event; source=content_by_lua, event=request3, wid=\d+$/
 
             -- non-serializable test data containing a function value
             -- use "nil" as data, reproducing issue #5
-            post("content_by_lua","test_event", nil)
+            post("content_by_lua", "test_event", nil)
 
             ngx.say("ok")
         }
@@ -165,6 +166,7 @@ something went wrong here!
 [crit]
 [alert]
 [emerg]
+
 
 
 === TEST 3: callback error stacktrace
@@ -190,7 +192,7 @@ something went wrong here!
             end
 
             ec:subscribe("*", "*", test_callback)
-            post("content_by_lua","test_event")
+            post("content_by_lua", "test_event")
 
             ngx.say("ok")
         }
@@ -207,5 +209,3 @@ in function 'in_between'
 [crit]
 [alert]
 [emerg]
-
-

--- a/t/events-compat.t
+++ b/t/events-compat.t
@@ -37,7 +37,7 @@ __DATA__
         assert(ev.configured())
 
         ev.register(function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", data=", data)
                 end)
     }
@@ -55,9 +55,9 @@ __DATA__
         content_by_lua_block {
             local ev = require "resty.events.compat"
 
-            ev.post("content_by_lua","request1","01234567890")
-            ev.post_local("content_by_lua","request2","01234567890")
-            ev.post("content_by_lua","request3","01234567890")
+            ev.post("content_by_lua", "request1", "01234567890")
+            ev.post_local("content_by_lua", "request2", "01234567890")
+            ev.post("content_by_lua", "request3", "01234567890")
 
             ngx.say("ok")
         }
@@ -80,6 +80,7 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890$/
+
 
 
 === TEST 2: worker.events handling remote events
@@ -100,7 +101,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
         assert(ev.configured())
 
         ev.register(function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", data=", tostring(data))
                 end)
     }
@@ -118,9 +119,9 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
         content_by_lua_block {
             local ev = require "resty.events.compat"
 
-            ev.post("content_by_lua","request1","01234567890")
-            ev.post_local("content_by_lua","request2","01234567890")
-            ev.post("content_by_lua","request3","01234567890")
+            ev.post("content_by_lua", "request1", "01234567890")
+            ev.post_local("content_by_lua", "request2", "01234567890")
+            ev.post("content_by_lua", "request3", "01234567890")
 
             ngx.say("ok")
         }
@@ -143,6 +144,7 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890$/
+
 
 
 === TEST 3: worker.events 'one' being done, and only once
@@ -164,7 +166,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
         assert(ev.configured())
 
         ev.register(function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", data=", tostring(data))
                 end)
     }
@@ -182,15 +184,15 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
         content_by_lua_block {
             local ev = require "resty.events.compat"
 
-            ev.post("content_by_lua","request1","01234567890")
-            ev.post("content_by_lua","request2","01234567890", "unique_value")
-            ev.post("content_by_lua","request3","01234567890", "unique_value")
+            ev.post("content_by_lua", "request1", "01234567890")
+            ev.post("content_by_lua", "request2", "01234567890", "unique_value")
+            ev.post("content_by_lua", "request3", "01234567890", "unique_value")
 
             ngx.sleep(0.1) -- wait for unique timeout to expire
 
-            ev.post("content_by_lua","request4","01234567890", "unique_value")
-            ev.post("content_by_lua","request5","01234567890", "unique_value")
-            ev.post("content_by_lua","request6","01234567890")
+            ev.post("content_by_lua", "request4", "01234567890", "unique_value")
+            ev.post("content_by_lua", "request5", "01234567890", "unique_value")
+            ev.post("content_by_lua", "request6", "01234567890")
 
             ngx.say("ok")
         }
@@ -216,6 +218,3 @@ worker-events: handling event; source=content_by_lua, event=request4, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request4, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request6, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890$/
-
-
-

--- a/t/events.t
+++ b/t/events.t
@@ -41,7 +41,7 @@ __DATA__
         assert(not ev:is_ready())
 
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", data=", data)
                 end)
 
@@ -63,9 +63,9 @@ __DATA__
 
             assert(ev:is_ready())
 
-            ev:publish("all", "content_by_lua","request1","01234567890")
-            ev:publish("current", "content_by_lua","request2","01234567890")
-            ev:publish("all", "content_by_lua","request3","01234567890")
+            ev:publish("all", "content_by_lua", "request1", "01234567890")
+            ev:publish("current", "content_by_lua", "request2", "01234567890")
+            ev:publish("all", "content_by_lua", "request3", "01234567890")
 
             ngx.say("ok")
         }
@@ -88,6 +88,7 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890$/
+
 
 
 === TEST 2: worker.events handling remote events
@@ -112,7 +113,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
         assert(not ev:is_ready())
 
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", data=", tostring(data))
                 end)
 
@@ -134,9 +135,9 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 
             assert(ev:is_ready())
 
-            ev:publish("all", "content_by_lua","request1","01234567890")
-            ev:publish("current", "content_by_lua","request2","01234567890")
-            ev:publish("all", "content_by_lua","request3","01234567890")
+            ev:publish("all", "content_by_lua", "request1", "01234567890")
+            ev:publish("current", "content_by_lua", "request2", "01234567890")
+            ev:publish("all", "content_by_lua", "request3", "01234567890")
 
             ngx.say("ok")
         }
@@ -159,6 +160,7 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890$/
+
 
 
 === TEST 3: worker.events 'one' being done, and only once
@@ -184,7 +186,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
         assert(not ev:is_ready())
 
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", data=", tostring(data))
                 end)
 
@@ -206,15 +208,15 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 
             assert(ev:is_ready())
 
-            ev:publish("all", "content_by_lua","request1","01234567890")
-            ev:publish("unique_value", "content_by_lua","request2","01234567890")
-            ev:publish("unique_value", "content_by_lua","request3","01234567890")
+            ev:publish("all", "content_by_lua", "request1", "01234567890")
+            ev:publish("unique_value", "content_by_lua", "request2", "01234567890")
+            ev:publish("unique_value", "content_by_lua", "request3", "01234567890")
 
             ngx.sleep(0.1) -- wait for unique timeout to expire
 
-            ev:publish("unique_value", "content_by_lua","request4","01234567890")
-            ev:publish("unique_value", "content_by_lua","request5","01234567890")
-            ev:publish("all", "content_by_lua","request6","01234567890")
+            ev:publish("unique_value", "content_by_lua", "request4", "01234567890")
+            ev:publish("unique_value", "content_by_lua", "request5", "01234567890")
+            ev:publish("all", "content_by_lua", "request6", "01234567890")
 
             ngx.say("ok")
         }
@@ -242,6 +244,7 @@ worker-events: handling event; source=content_by_lua, event=request6, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890$/
 
 
+
 === TEST 4: publish events at anywhere
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
@@ -256,7 +259,7 @@ worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, d
             ngx.log(ngx.ERR, "failed to new events")
         end
 
-        ev:publish("all", "content_by_lua","request1","01234567890")
+        ev:publish("all", "content_by_lua", "request1", "01234567890")
 
         local ok, err = ev:init_worker()
         if not ok then
@@ -265,14 +268,14 @@ worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, d
 
         assert(not ev:is_ready())
 
-        ev:publish("current", "content_by_lua","request2","01234567890")
+        ev:publish("current", "content_by_lua", "request2", "01234567890")
 
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", data=", tostring(data))
                 end)
 
-        ev:publish("all", "content_by_lua","request3","01234567890")
+        ev:publish("all", "content_by_lua", "request3", "01234567890")
 
         _G.ev = ev
     }
@@ -309,6 +312,7 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890$/
+
 
 
 === TEST 5: configure with wrong params
@@ -399,6 +403,7 @@ optional "unique_timeout" option must be a number
 [emerg]
 
 
+
 === TEST 6: publish events exceeding 65535 bytes
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
@@ -422,7 +427,7 @@ optional "unique_timeout" option must be a number
         assert(not ev:is_ready())
 
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", big=", #data > 65535)
                 end)
 
@@ -456,7 +461,7 @@ optional "unique_timeout" option must be a number
                                        string.rep("a", 1024*1024))
             ngx.say(err)
 
-            ok, err = ev:publish("all", "content_by_lua","request4","01234567890")
+            ok, err = ev:publish("all", "content_by_lua", "request4", "01234567890")
             ngx.say(err)
 
             ngx.say("ok")
@@ -487,6 +492,7 @@ worker-events: handling event; source=content_by_lua, event=request4, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request4, wid=\d+, big=false$/
 
 
+
 === TEST 7: customize publish events limitation
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
@@ -510,7 +516,7 @@ worker-events: handler event;  source=content_by_lua, event=request4, wid=\d+, b
         assert(not ev:is_ready())
 
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", data=", data)
                 end)
 
@@ -562,4 +568,3 @@ ok
 --- grep_error_log_out eval
 qr/^worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890$/
-

--- a/t/listening-off.t
+++ b/t/listening-off.t
@@ -42,7 +42,7 @@ __DATA__
         assert(not ev:is_ready())
 
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", data=", data)
                 end)
 
@@ -55,9 +55,9 @@ __DATA__
 
             assert(ev:is_ready())
 
-            ev:publish("all", "content_by_lua","request1","01234567890")
-            ev:publish("current", "content_by_lua","request2","01234567890")
-            ev:publish("all", "content_by_lua","request3","01234567890")
+            ev:publish("all", "content_by_lua", "request1", "01234567890")
+            ev:publish("current", "content_by_lua", "request2", "01234567890")
+            ev:publish("all", "content_by_lua", "request3", "01234567890")
 
             ngx.say("ok")
         }
@@ -80,6 +80,7 @@ worker-events: handling event; source=content_by_lua, event=request2, wid=nil
 worker-events: handler event;  source=content_by_lua, event=request2, wid=nil, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=nil
 worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, data=01234567890$/
+
 
 
 === TEST 2: worker.events handling remote events
@@ -105,7 +106,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, d
         assert(not ev:is_ready())
 
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", data=", tostring(data))
                 end)
 
@@ -118,9 +119,9 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, d
 
             assert(ev:is_ready())
 
-            ev:publish("all", "content_by_lua","request1","01234567890")
-            ev:publish("current", "content_by_lua","request2","01234567890")
-            ev:publish("all", "content_by_lua","request3","01234567890")
+            ev:publish("all", "content_by_lua", "request1", "01234567890")
+            ev:publish("current", "content_by_lua", "request2", "01234567890")
+            ev:publish("all", "content_by_lua", "request3", "01234567890")
 
             ngx.say("ok")
         }
@@ -143,6 +144,7 @@ worker-events: handling event; source=content_by_lua, event=request2, wid=nil
 worker-events: handler event;  source=content_by_lua, event=request2, wid=nil, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=nil
 worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, data=01234567890$/
+
 
 
 === TEST 3: worker.events 'one' being done, and only once
@@ -169,7 +171,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, d
         assert(not ev:is_ready())
 
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", data=", tostring(data))
                 end)
 
@@ -182,15 +184,15 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, d
 
             assert(ev:is_ready())
 
-            ev:publish("all", "content_by_lua","request1","01234567890")
-            ev:publish("unique_value", "content_by_lua","request2","01234567890")
-            ev:publish("unique_value", "content_by_lua","request3","01234567890")
+            ev:publish("all", "content_by_lua", "request1", "01234567890")
+            ev:publish("unique_value", "content_by_lua", "request2", "01234567890")
+            ev:publish("unique_value", "content_by_lua", "request3", "01234567890")
 
             ngx.sleep(0.1) -- wait for unique timeout to expire
 
-            ev:publish("unique_value", "content_by_lua","request4","01234567890")
-            ev:publish("unique_value", "content_by_lua","request5","01234567890")
-            ev:publish("all", "content_by_lua","request6","01234567890")
+            ev:publish("unique_value", "content_by_lua", "request4", "01234567890")
+            ev:publish("unique_value", "content_by_lua", "request5", "01234567890")
+            ev:publish("all", "content_by_lua", "request6", "01234567890")
 
             ngx.say("ok")
         }
@@ -221,6 +223,7 @@ worker-events: handling event; source=content_by_lua, event=request6, wid=nil
 worker-events: handler event;  source=content_by_lua, event=request6, wid=nil, data=01234567890$/
 
 
+
 === TEST 4: publish events at anywhere
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
@@ -237,11 +240,11 @@ worker-events: handler event;  source=content_by_lua, event=request6, wid=nil, d
         end
 
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                     ", data=", tostring(data))
                 end)
 
-        ev:publish("all", "content_by_lua","request1","01234567890")
+        ev:publish("all", "content_by_lua", "request1", "01234567890")
 
         local ok, err = ev:init_worker()
         if not ok then
@@ -250,9 +253,9 @@ worker-events: handler event;  source=content_by_lua, event=request6, wid=nil, d
 
         assert(not ev:is_ready())
 
-        ev:publish("current", "content_by_lua","request2","01234567890")
+        ev:publish("current", "content_by_lua", "request2", "01234567890")
 
-        ev:publish("all", "content_by_lua","request3","01234567890")
+        ev:publish("all", "content_by_lua", "request3", "01234567890")
 
         _G.ev = ev
     }
@@ -280,5 +283,3 @@ worker-events: handling event; source=content_by_lua, event=request2, wid=nil
 worker-events: handler event;  source=content_by_lua, event=request2, wid=nil, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=nil
 worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, data=01234567890$/
-
-

--- a/t/privileged.t
+++ b/t/privileged.t
@@ -7,7 +7,7 @@ use Test::Nginx::Socket::Lua;
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 8) + 2;
+plan tests => repeat_each() * (blocks() * 15) + 2;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
@@ -18,7 +18,6 @@ workers(3);
 run_tests();
 
 __DATA__
-
 
 === TEST 1: posting events and handling events, broadcast
 --- http_config
@@ -43,10 +42,13 @@ __DATA__
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
         end
 
+        local i = 0
+
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
-                    ", data=", data)
-                end)
+            i = i + 1
+            ngx.log(ngx.DEBUG, i, " worker-events: handler event; source=", source, ", event=", event,
+                               ", wid=", wid, ", by=", (ngx.worker.id() or "nil"), ", data=", data)
+        end)
 
         _G.ev = ev
     }
@@ -73,23 +75,26 @@ __DATA__
 GET /test
 --- response_body
 ok
---- error_log
-event published to 4 workers
-setproctitle: "nginx: privileged agent process"
+--- error_log eval
+[
+    qr/privileged agent process/,
+    qr/event published to 4 workers/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=0, data=01234567890/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=1, data=01234567890/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=2, data=01234567890/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=nil, data=01234567890/
+]
 --- no_error_log
 [error]
 [crit]
 [alert]
---- grep_error_log eval: qr/worker-events: .*/
+--- grep_error_log eval: qr/worker-events: handling event; .*/
 --- grep_error_log_out eval
 qr/^worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890$/
+worker-events: handling event; source=content_by_lua, event=request1, wid=\d+$/
+
 
 
 === TEST 2: posting events and handling events, local
@@ -115,10 +120,18 @@ worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, d
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
         end
 
+        local i = 0
+
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=", source,", event=", event, ", wid=", wid,
-                    ", data=", data)
-                end)
+            if wid then
+                i = 3
+            else
+                i = i + 1
+            end
+
+            ngx.log(ngx.DEBUG, i, " worker-events: handler event; source=", source, ", event=", event,
+                               ", wid=", wid, ", by=", (ngx.worker.id() or "nil"), ", data=", data)
+        end)
 
         _G.ev = ev
     }
@@ -136,9 +149,9 @@ worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, d
         content_by_lua_block {
             local ev = _G.ev
 
-            ev:publish("current", "content_by_lua","request1","01234567890")
-            ev:publish("current", "content_by_lua","request2","01234567890")
-            ev:publish("all", "content_by_lua","request3","01234567890")
+            ev:publish("current", "content_by_lua", "request1", "ABCDEFGHIJK")
+            ev:publish("current", "content_by_lua", "request2", "LMNOPQRSTUV")
+            ev:publish("all", "content_by_lua", "request3", "01234567890")
 
             ngx.say("ok")
         }
@@ -147,27 +160,30 @@ worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, d
 GET /test
 --- response_body
 ok
---- error_log
-event published to 4 workers
-setproctitle: "nginx: privileged agent process"
+--- error_log eval
+[
+    qr/privileged agent process/,
+    qr/event published to 4 workers/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=nil, by=\d+, data=ABCDEFGHIJK/,
+    qr/2 worker-events: handler event; source=content_by_lua, event=request2, wid=nil, by=\d+, data=LMNOPQRSTUV/,
+    qr/3 worker-events: handler event; source=content_by_lua, event=request3, wid=\d+, by=0, data=01234567890/,
+    qr/3 worker-events: handler event; source=content_by_lua, event=request3, wid=\d+, by=1, data=01234567890/,
+    qr/3 worker-events: handler event; source=content_by_lua, event=request3, wid=\d+, by=2, data=01234567890/,
+    qr/3 worker-events: handler event; source=content_by_lua, event=request3, wid=\d+, by=nil, data=01234567890/
+]
 --- no_error_log
 [error]
 [crit]
 [alert]
---- grep_error_log eval: qr/worker-events: .*/
+--- grep_error_log eval: qr/worker-events: handling event; .*/
 --- grep_error_log_out eval
 qr/^worker-events: handling event; source=content_by_lua, event=request1, wid=nil
-worker-events: handler event;  source=content_by_lua, event=request1, wid=nil, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request2, wid=nil
-worker-events: handler event;  source=content_by_lua, event=request2, wid=nil, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890
-worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890$/
+worker-events: handling event; source=content_by_lua, event=request3, wid=\d+$/
+
 
 
 === TEST 3: worker.events 'one' being done, and only once
@@ -195,9 +211,9 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
         end
 
         ev:subscribe("*", "*", function(data, event, source, wid)
-            ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=", source, ", event=", event, ", wid=", wid,
-                    ", data=", tostring(data))
-                end)
+            ngx.log(ngx.DEBUG, "worker-events: handler event; source=", source, ", event=", event,
+                               ", wid=", wid, ", by=", (ngx.worker.id() or "nil"), ", data=", data)
+        end)
 
         _G.ev = ev
     }
@@ -215,21 +231,17 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
         content_by_lua_block {
             local ev = _G.ev
 
-            ev:publish("all", "content_by_lua","request1","01234567890")
+            ev:publish("all", "content_by_lua", "request1", "01234567890")
 
-            ngx.sleep(0.05) -- wait for logs
-
-            ev:publish("unique_value", "content_by_lua", "request2", "01234567890")
-            ev:publish("unique_value", "content_by_lua", "request3", "01234567890")
+            ev:publish("unique_value", "content_by_lua", "request2", "ABCDEFGHIJK")
+            ev:publish("unique_value", "content_by_lua", "request3", "LMNOPQRSTUV")
 
             ngx.sleep(0.1) -- wait for unique timeout to expire
 
-            ev:publish("unique_value", "content_by_lua", "request4", "01234567890")
-            ev:publish("unique_value", "content_by_lua", "request5", "01234567890")
+            ev:publish("unique_value", "content_by_lua", "request4", "WXYZABCDEFG")
+            ev:publish("unique_value", "content_by_lua", "request5", "HIJKLMNOPQR")
 
-            ngx.sleep(0.05) -- wait for logs
-
-            ev:publish("all", "content_by_lua", "request6", "01234567890")
+            ev:publish("all", "content_by_lua", "request6", "STUVWXYZABC")
 
             ngx.say("ok")
         }
@@ -238,27 +250,27 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 GET /test
 --- response_body
 ok
---- error_log
-event published to 1 workers
-unique event is duplicate: unique_value
-event published to 4 workers
-setproctitle: "nginx: privileged agent process"
+--- error_log eval
+[
+    qr/privileged agent process/,
+    qr/event published to 1 workers/,
+    qr/unique event is duplicate: unique_value/,
+    qr/event published to 4 workers/,
+    qr/worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=0, data=01234567890/,
+    qr/worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=1, data=01234567890/,
+    qr/worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=2, data=01234567890/,
+    qr/worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=nil, data=01234567890/,
+    qr/worker-events: handler event; source=content_by_lua, event=request2, wid=\d+, by=(\d+|nil), data=ABCDEFGHIJK/,
+    qr/worker-events: handler event; source=content_by_lua, event=request4, wid=\d+, by=(\d+|nil), data=WXYZABCDEFG/,
+    qr/worker-events: handler event; source=content_by_lua, event=request6, wid=\d+, by=0, data=STUVWXYZABC/,
+    qr/worker-events: handler event; source=content_by_lua, event=request6, wid=\d+, by=1, data=STUVWXYZABC/,
+    qr/worker-events: handler event; source=content_by_lua, event=request6, wid=\d+, by=2, data=STUVWXYZABC/,
+    qr/worker-events: handler event; source=content_by_lua, event=request6, wid=\d+, by=nil, data=STUVWXYZABC/
+]
+
 --- no_error_log
 [error]
 [crit]
 [alert]
---- grep_error_log eval: qr/worker-events: handler .*/
---- grep_error_log_out eval
-qr/^worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request2, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request4, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890$/
-
-
-
+LMNOPQRSTUV
+HIJKLMNOPQR

--- a/t/stream-broadcast.t
+++ b/t/stream-broadcast.t
@@ -7,7 +7,7 @@ use Test::Nginx::Socket::Lua;
 
 #repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 7) + 2;
+plan tests => repeat_each() * (blocks() * 14) + 2;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
@@ -18,7 +18,6 @@ workers(4);
 run_tests();
 
 __DATA__
-
 
 === TEST 1: posting events and handling events, broadcast
 --- main_config
@@ -40,10 +39,13 @@ __DATA__
                 ngx.log(ngx.ERR, "failed to init_worker events: ", err)
             end
 
+            local i = 0
+
             ev:subscribe("*", "*", function(data, event, source, wid)
-                ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
-                        ", data=", data)
-                    end)
+                i = i + 1
+                ngx.log(ngx.DEBUG, i, " worker-events: handler event; source=", source, ", event=", event,
+                                   ", wid=", wid, ", by=", ngx.worker.id(), ", data=", data)
+            end)
 
             _G.ev = ev
         }
@@ -59,7 +61,7 @@ __DATA__
             content_by_lua_block {
                 local ev = _G.ev
 
-                ev:publish("all", "content_by_lua","request1","01234567890")
+                ev:publish("all", "content_by_lua", "request1", "01234567890")
 
                 ngx.say("ok")
             }
@@ -91,22 +93,25 @@ __DATA__
 GET /test
 --- response_body
 ok
---- error_log
-event published to 4 workers
+--- error_log eval
+[
+    qr/event published to 4 workers/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=0, data=01234567890/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=1, data=01234567890/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=2, data=01234567890/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=3, data=01234567890/
+]
 --- no_error_log
 [error]
 [crit]
 [alert]
---- grep_error_log eval: qr/worker-events: .*/
+--- grep_error_log eval: qr/worker-events: handling event; .*/
 --- grep_error_log_out eval
 qr/^worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890$/
+worker-events: handling event; source=content_by_lua, event=request1, wid=\d+$/
+
 
 
 === TEST 2: posting events and handling events, local
@@ -129,10 +134,18 @@ worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, d
                 ngx.log(ngx.ERR, "failed to init_worker events: ", err)
             end
 
+            local i = 0
+
             ev:subscribe("*", "*", function(data, event, source, wid)
-                ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
-                        ", data=", data)
-                    end)
+                if wid then
+                    i = 3
+                else
+                    i = i + 1
+                end
+
+                ngx.log(ngx.DEBUG, i, " worker-events: handler event; source=", source, ", event=", event,
+                                   ", wid=", wid, ", by=", ngx.worker.id(), ", data=", data)
+            end)
 
             _G.ev = ev
         }
@@ -148,9 +161,9 @@ worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, d
             content_by_lua_block {
                 local ev = _G.ev
 
-                ev:publish("current", "content_by_lua","request1","01234567890")
-                ev:publish("current", "content_by_lua","request2","01234567890")
-                ev:publish("all", "content_by_lua","request3","01234567890")
+                ev:publish("current", "content_by_lua", "request1", "ABCDEFGHIJK")
+                ev:publish("current", "content_by_lua", "request2", "LMNOPQRSTUV")
+                ev:publish("all", "content_by_lua", "request3", "01234567890")
 
                 ngx.say("ok")
             }
@@ -182,26 +195,29 @@ worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, d
 GET /test
 --- response_body
 ok
---- error_log
-event published to 4 workers
+--- error_log eval
+[
+    qr/event published to 4 workers/,
+    qr/1 worker-events: handler event; source=content_by_lua, event=request1, wid=nil, by=\d+, data=ABCDEFGHIJK/,
+    qr/2 worker-events: handler event; source=content_by_lua, event=request2, wid=nil, by=\d+, data=LMNOPQRSTUV/,
+    qr/3 worker-events: handler event; source=content_by_lua, event=request3, wid=\d+, by=0, data=01234567890/,
+    qr/3 worker-events: handler event; source=content_by_lua, event=request3, wid=\d+, by=1, data=01234567890/,
+    qr/3 worker-events: handler event; source=content_by_lua, event=request3, wid=\d+, by=2, data=01234567890/,
+    qr/3 worker-events: handler event; source=content_by_lua, event=request3, wid=\d+, by=3, data=01234567890/
+]
 --- no_error_log
 [error]
 [crit]
 [alert]
---- grep_error_log eval: qr/worker-events: .*/
+--- grep_error_log eval: qr/worker-events: handling event; .*/
 --- grep_error_log_out eval
 qr/^worker-events: handling event; source=content_by_lua, event=request1, wid=nil
-worker-events: handler event;  source=content_by_lua, event=request1, wid=nil, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request2, wid=nil
-worker-events: handler event;  source=content_by_lua, event=request2, wid=nil, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890
-worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
-worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890$/
+worker-events: handling event; source=content_by_lua, event=request3, wid=\d+$/
+
 
 
 === TEST 3: worker.events 'one' being done, and only once
@@ -226,9 +242,9 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
             end
 
             ev:subscribe("*", "*", function(data, event, source, wid)
-                ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
-                        ", data=", tostring(data))
-                    end)
+                ngx.log(ngx.DEBUG, "worker-events: handler event; source=", source, ", event=", event,
+                                   ", wid=", wid, ", by=", ngx.worker.id(), ", data=", data)
+            end)
 
             _G.ev = ev
         }
@@ -244,21 +260,17 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
             content_by_lua_block {
                 local ev = _G.ev
 
-                ev:publish("all", "content_by_lua","request1","01234567890")
+                ev:publish("all", "content_by_lua", "request1", "01234567890")
 
-                ngx.sleep(0.05) -- wait for logs
-
-                ev:publish("unique_value", "content_by_lua","request2","01234567890")
-                ev:publish("unique_value", "content_by_lua","request3","01234567890")
+                ev:publish("unique_value", "content_by_lua", "request2", "ABCDEFGHIJK")
+                ev:publish("unique_value", "content_by_lua", "request3", "LMNOPQRSTUV")
 
                 ngx.sleep(0.1) -- wait for unique timeout to expire
 
-                ev:publish("unique_value", "content_by_lua","request4","01234567890")
-                ev:publish("unique_value", "content_by_lua","request5","01234567890")
+                ev:publish("unique_value", "content_by_lua", "request4", "WXYZABCDEFG")
+                ev:publish("unique_value", "content_by_lua", "request5", "HIJKLMNOPQR")
 
-                ngx.sleep(0.05) -- wait for logs
-
-                ev:publish("all", "content_by_lua","request6","01234567890")
+                ev:publish("all", "content_by_lua", "request6", "STUVWXYZABC")
 
                 ngx.say("ok")
             }
@@ -290,26 +302,25 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 GET /test
 --- response_body
 ok
---- error_log
-event published to 1 workers
-unique event is duplicate: unique_value
-event published to 4 workers
+--- error_log eval
+[
+    qr/event published to 1 workers/,
+    qr/unique event is duplicate: unique_value/,
+    qr/event published to 4 workers/,
+    qr/worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=0, data=01234567890/,
+    qr/worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=1, data=01234567890/,
+    qr/worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=2, data=01234567890/,
+    qr/worker-events: handler event; source=content_by_lua, event=request1, wid=\d+, by=3, data=01234567890/,
+    qr/worker-events: handler event; source=content_by_lua, event=request2, wid=\d+, by=\d+, data=ABCDEFGHIJK/,
+    qr/worker-events: handler event; source=content_by_lua, event=request4, wid=\d+, by=\d+, data=WXYZABCDEFG/,
+    qr/worker-events: handler event; source=content_by_lua, event=request6, wid=\d+, by=0, data=STUVWXYZABC/,
+    qr/worker-events: handler event; source=content_by_lua, event=request6, wid=\d+, by=1, data=STUVWXYZABC/,
+    qr/worker-events: handler event; source=content_by_lua, event=request6, wid=\d+, by=2, data=STUVWXYZABC/,
+    qr/worker-events: handler event; source=content_by_lua, event=request6, wid=\d+, by=3, data=STUVWXYZABC/
+]
 --- no_error_log
 [error]
 [crit]
 [alert]
---- grep_error_log eval: qr/worker-events: handler .*/
---- grep_error_log_out eval
-qr/^worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request2, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request4, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890
-worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890$/
-
-
-
+LMNOPQRSTUV
+HIJKLMNOPQR

--- a/t/stream-events.t
+++ b/t/stream-events.t
@@ -40,7 +40,7 @@ __DATA__
             end
 
             ev:subscribe("*", "*", function(data, event, source, wid)
-                ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+                ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                         ", data=", data)
                     end)
 
@@ -58,9 +58,9 @@ __DATA__
             content_by_lua_block {
                 local ev = _G.ev
 
-                ev:publish("all", "content_by_lua","request1","01234567890")
-                ev:publish("current", "content_by_lua","request2","01234567890")
-                ev:publish("all", "content_by_lua","request3","01234567890")
+                ev:publish("all", "content_by_lua", "request1", "01234567890")
+                ev:publish("current", "content_by_lua", "request2", "01234567890")
+                ev:publish("all", "content_by_lua", "request3", "01234567890")
 
                 ngx.say("ok")
             }
@@ -106,6 +106,7 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890$/
+
 
 
 === TEST 2: worker.events handling remote events
@@ -129,7 +130,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
             end
 
             ev:subscribe("*", "*", function(data, event, source, wid)
-                ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+                ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                         ", data=", tostring(data))
                     end)
 
@@ -148,9 +149,9 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
             content_by_lua_block {
                 local ev = _G.ev
 
-                ev:publish("all", "content_by_lua","request1","01234567890")
-                ev:publish("current", "content_by_lua","request2","01234567890")
-                ev:publish("all", "content_by_lua","request3","01234567890")
+                ev:publish("all", "content_by_lua", "request1", "01234567890")
+                ev:publish("current", "content_by_lua", "request2", "01234567890")
+                ev:publish("all", "content_by_lua", "request3", "01234567890")
 
                 ngx.say("ok")
             }
@@ -196,6 +197,7 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request1, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request3, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, data=01234567890$/
+
 
 
 === TEST 3: worker.events 'one' being done, and only once
@@ -220,7 +222,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
             end
 
             ev:subscribe("*", "*", function(data, event, source, wid)
-                ngx.log(ngx.DEBUG, "worker-events: handler event;  ","source=",source,", event=",event, ", wid=", wid,
+                ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                         ", data=", tostring(data))
                     end)
 
@@ -238,15 +240,15 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
             content_by_lua_block {
                 local ev = _G.ev
 
-                ev:publish("all", "content_by_lua","request1","01234567890")
-                ev:publish("unique_value", "content_by_lua","request2","01234567890")
-                ev:publish("unique_value", "content_by_lua","request3","01234567890")
+                ev:publish("all", "content_by_lua", "request1", "01234567890")
+                ev:publish("unique_value", "content_by_lua", "request2", "01234567890")
+                ev:publish("unique_value", "content_by_lua", "request3", "01234567890")
 
                 ngx.sleep(0.1) -- wait for unique timeout to expire
 
-                ev:publish("unique_value", "content_by_lua","request4","01234567890")
-                ev:publish("unique_value", "content_by_lua","request5","01234567890")
-                ev:publish("all", "content_by_lua","request6","01234567890")
+                ev:publish("unique_value", "content_by_lua", "request4", "01234567890")
+                ev:publish("unique_value", "content_by_lua", "request5", "01234567890")
+                ev:publish("all", "content_by_lua", "request6", "01234567890")
 
                 ngx.say("ok")
             }
@@ -295,6 +297,3 @@ worker-events: handling event; source=content_by_lua, event=request4, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request4, wid=\d+, data=01234567890
 worker-events: handling event; source=content_by_lua, event=request6, wid=\d+
 worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, data=01234567890$/
-
-
-


### PR DESCRIPTION
### Summary

This is discussed in FTI-5930 and a workaround for this issue was proposed in: https://github.com/Kong/kong/pull/13004

Before (dbless node):

1. Worker 0 gets "reconfigure" event and acquires coroutine mutex
2. Worker 1 gets "reconfigure" event and acquires coroutine mutex
3. Worker 0 crashes and with it the events broker crashes too
4. Worker 1 restarts its events processing because of connection issue to events broker and it prematurely kills the executing "reconfigure" event handler as well, that then doesn't release its mutex.
5. Worker 0 restarts with pristine state (only the possible and time-outing node level locks are retained)
6. Worker 0 gets "reconfigure" event and acquires coroutine mutex
7. Worker 1 gets "reconfigure" event and is now in deadlock situation

After (dbless node):

1. Worker 0 gets "reconfigure" event and acquires coroutine mutex
2. Worker 1 gets "reconfigure" event and acquires coroutine mutex
3. Worker 0 crashes and with it the events broker crashes too
4. Worker 1 restarts its events processing because of connection issue to events broker but it finishes the execution of an executing event handlers allowing the release of locks
5. Worker 0 restarts with pristine state (only the possible and time-outing node level locks are retained)
6. Worker 0 gets "reconfigure" event and acquires coroutine mutex
7. Worker 1 gets "reconfigure" event and acquires coroutine mutex