### PR TITLE
 fix(broker): retry broadcast unique event on failure

### DIFF
--- a/lualib/resty/events/broker.lua
+++ b/lualib/resty/events/broker.lua
@@ -2,14 +2,13 @@ local cjson = require "cjson.safe"
 local nkeys = require "table.nkeys"
 local codec = require "resty.events.codec"
 local lrucache = require "resty.lrucache"
-
-local que = require "resty.events.queue"
+local queue = require "resty.events.queue"
 local server = require("resty.events.protocol").server
 local is_timeout = server.is_timeout
+local is_closed = server.is_closed
 
 local pairs = pairs
 local setmetatable = setmetatable
-local str_sub = string.sub
 local random = math.random
 
 local ngx = ngx
@@ -28,11 +27,10 @@ local decode = codec.decode
 local cjson_encode = cjson.encode
 
 local MAX_UNIQUE_EVENTS = 1024
+local WEAK_KEYS_MT = { __mode = "k", }
 
-local function is_closed(err)
-    return err and
-           (str_sub(err, -6) == "closed" or
-            str_sub(err, -11) == "broken pipe")
+local function terminating(self, worker_connection)
+    return self._clients[worker_connection] == nil or exiting()
 end
 
 -- broadcast to all/unique workers
@@ -73,19 +71,87 @@ local function broadcast_events(self, unique, data)
     log(DEBUG, "event published to ", n, " workers")
 end
 
+local function read_thread(self, worker_connection)
+    while not terminating(self, worker_connection) do
+        local data, err = worker_connection:recv_frame()
+        if err then
+            if not is_timeout(err) then
+                return nil, "failed to read event from worker: " .. err
+            end
+
+            -- timeout
+            goto continue
+        end
+
+        if not data then
+            if not exiting() then
+                log(ERR, "did not receive event from worker")
+            end
+            goto continue
+        end
+
+        local event_data, err = decode(data)
+        if not event_data then
+            if not exiting() then
+                log(ERR, "failed to decode event data: ", err)
+            end
+            goto continue
+        end
+
+        -- unique event
+        local unique = event_data.spec.unique
+        if unique then
+            if self._uniques:get(unique) then
+                log(DEBUG, "unique event is duplicate: ", unique)
+                goto continue
+            end
+
+            self._uniques:set(unique, 1, self._opts.unique_timeout)
+        end
+
+        -- broadcast to all/unique workers
+        broadcast_events(self, unique, event_data.data)
+
+        ::continue::
+    end -- while not terminating
+
+    return true
+end
+
+local function write_thread(self, worker_connection)
+    while not terminating(self, worker_connection) do
+        local payload, err = self._clients[worker_connection]:pop()
+        if not payload then
+            if not is_timeout(err) then
+                return nil, "semaphore wait error: " .. err
+            end
+
+            goto continue
+        end
+
+        local _, err = worker_connection:send_frame(payload)
+        if err then
+            return nil, "failed to send event: " .. err
+        end
+
+        ::continue::
+    end -- while not terminating
+
+    return true
+end
+
 local _M = {
     _VERSION = '0.1.3',
 }
+
 local _MT = { __index = _M, }
 
 function _M.new(opts)
-    local self = {
+    return setmetatable({
         _opts = opts,
         _uniques = nil,
         _clients = nil,
-    }
-
-    return setmetatable(self, _MT)
+    }, _MT)
 end
 
 function _M:init()
@@ -96,108 +162,33 @@ function _M:init()
         return nil, "failed to create the events cache: " .. (err or "unknown")
     end
 
-    local _clients = setmetatable({}, { __mode = "k", })
-
     self._uniques = _uniques
-    self._clients = _clients
+    self._clients = setmetatable({}, WEAK_KEYS_MT)
 
     return true
 end
 
 function _M:run()
-    local conn, err = server:new()
-
-    if not conn then
+    local worker_connection, err = server.new()
+    if not worker_connection then
         log(ERR, "failed to init socket: ", err)
         exit(444)
     end
 
-    local queue = que.new(self._opts.max_queue_len)
+    self._clients[worker_connection] = queue.new(self._opts.max_queue_len)
 
-    self._clients[conn] = queue
+    local read_thread_co = spawn(read_thread, self, worker_connection)
+    local write_thread_co = spawn(write_thread, self, worker_connection)
 
-    local read_thread = spawn(function()
-        while not exiting() do
-            local data, err = conn:recv_frame()
+    local ok, err, perr = wait(read_thread_co, write_thread_co)
 
-            if exiting() then
-                return
-            end
+    self._clients[worker_connection] = nil
 
-            if err then
-                if not is_timeout(err) then
-                  return nil, err
-                end
-
-                -- timeout
-                goto continue
-            end
-
-            if not data then
-                return nil, "did not receive event from worker"
-            end
-
-            local d, err
-
-            d, err = decode(data)
-            if not d then
-                log(ERR, "failed to decode event data: ", err)
-                goto continue
-            end
-
-            -- unique event
-            local unique = d.spec.unique
-            if unique then
-                if self._uniques:get(unique) then
-                    log(DEBUG, "unique event is duplicate: ", unique)
-                    goto continue
-                end
-
-                self._uniques:set(unique, 1, self._opts.unique_timeout)
-            end
-
-            -- broadcast to all/unique workers
-            broadcast_events(self, unique, d.data)
-
-            ::continue::
-        end -- while not exiting
-    end)  -- read_thread
-
-    local write_thread = spawn(function()
-        while not exiting() do
-            local payload, err = queue:pop()
-
-            if not payload then
-                if not is_timeout(err) then
-                    return nil, "semaphore wait error: " .. err
-                end
-
-                goto continue
-            end
-
-            if exiting() then
-                return
-            end
-
-            local _, err = conn:send_frame(payload)
-            if err then
-                log(ERR, "failed to send event: ", err)
-            end
-
-            if is_closed(err) then
-                return
-            end
-
-            ::continue::
-        end -- while not exiting
-    end)  -- write_thread
-
-    local ok, err, perr = wait(write_thread, read_thread)
-
-    self._clients[conn] = nil
-
-    kill(write_thread)
-    kill(read_thread)
+    if exiting() then
+        kill(read_thread_co)
+        kill(write_thread_co)
+        return
+    end
 
     if not ok and not is_closed(err) then
         log(ERR, "event broker failed: ", err)
@@ -209,8 +200,10 @@ function _M:run()
         return exit(ngx.ERROR)
     end
 
+    wait(read_thread_co)
+    wait(write_thread_co)
+
     return exit(ngx.OK)
 end
 
 return _M
-


### PR DESCRIPTION
Missing most probably busted test (testing this with Test::Nginx is difficult)

Also this will be much smaller when:
https://github.com/Kong/lua-resty-events/pull/48 (thus currently it has two commits, the second is what this PR is all about).

Review: https://github.com/Kong/lua-resty-events/pull/49/commits/324fafdd8f308795f46708750a6f4adc79120723

KAG-4480