### PR TITLE
chore(*): release 0.2.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
         # TODO: arm64
         - openresty: "1.19.9.1"
         - openresty: "1.21.4.1"
-        - openresty: "1.21.4.2"
+        - openresty: "1.21.4.3"
         - openresty: "1.25.3.1"
 
     env:
@@ -62,4 +62,3 @@ jobs:
         export PATH=${BASE_PATH}/openresty/bin:$PATH
         openresty -V
         make test OPENRESTY_PREFIX=${BASE_PATH}/openresty
-

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022-2024 Kong Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ License
 =======
 
 ```
-Copyright 2022 Kong Inc.
+Copyright 2022-2024 Kong Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -266,4 +266,3 @@ See Also
 * Kong: https://konghq.com/
 
 [Back to TOC](#table-of-contents)
-

--- a/lualib/resty/events/broker.lua
+++ b/lualib/resty/events/broker.lua
@@ -140,10 +140,7 @@ local function write_thread(self, worker_connection)
     return true
 end
 
-local _M = {
-    _VERSION = '0.1.3',
-}
-
+local _M = {}
 local _MT = { __index = _M, }
 
 function _M.new(opts)

--- a/lualib/resty/events/callback.lua
+++ b/lualib/resty/events/callback.lua
@@ -14,9 +14,7 @@ local DEBUG = ngx.DEBUG
 
 local encode = cjson.encode
 
-local _M = {
-  _VERSION = '0.1.0',
-}
+local _M = {}
 local _MT = { __index = _M, }
 
 function _M.new()

--- a/lualib/resty/events/codec.lua
+++ b/lualib/resty/events/codec.lua
@@ -17,9 +17,7 @@ local buf_enc = buffer.new(options)
 local buf_dec = buffer.new(options)
 
 
-local _M = {
-    _VERSION = "0.1.0",
-}
+local _M = {}
 
 
 function _M.encode(obj)

--- a/lualib/resty/events/compat/init.lua
+++ b/lualib/resty/events/compat/init.lua
@@ -14,7 +14,7 @@ local handlers = {}
 local _configured
 
 local _M = {
-    _VERSION = '0.1.0',
+    _VERSION = "0.1.0",
 }
 
 function _M.poll()
@@ -29,7 +29,6 @@ function _M.configure(opts)
     ev = require("resty.events").new(opts)
 
     local ok, err = ev:init_worker()
-
     if not ok then
         return nil, err
     end
@@ -49,7 +48,6 @@ end
 
 _M.post = function(source, event, data, unique)
     local ok, err = ev:publish(unique or "all", source, event, data)
-
     if not ok then
         return nil, err
     end
@@ -59,7 +57,6 @@ end
 
 _M.post_local = function(source, event, data)
     local ok, err = ev:publish("current", source, event, data)
-
     if not ok then
         return nil, err
     end
@@ -69,19 +66,16 @@ end
 
 _M.register = function(callback, source, event, ...)
     local events = {event or "*", ...}
-
     for _, e in ipairs(events) do
         local id = ev:subscribe(source or "*", e or "*", callback)
-
         handlers[callback] = id
     end
 end
 
 _M.register_weak = _M.register
 
-_M.unregister = function(callback, source, ...)
+_M.unregister = function(callback)
     local id = handlers[callback]
-
     if not id then
         return
     end

--- a/lualib/resty/events/frame.lua
+++ b/lualib/resty/events/frame.lua
@@ -14,9 +14,7 @@ local assert = assert
 local tostring = tostring
 
 
-local _M = {
-    _VERSION = "0.2.0",
-}
+local _M = {}
 
 
 -- frame format: Len(3 bytes) + Payload(max to 2^24 - 1 bytes)

--- a/lualib/resty/events/init.lua
+++ b/lualib/resty/events/init.lua
@@ -13,7 +13,7 @@ local str_sub = string.sub
 local worker_count = ngx.worker.count()
 
 local _M = {
-    _VERSION = '0.2.0',
+    _VERSION = "0.2.1",
 }
 local _MT = { __index = _M, }
 

--- a/lualib/resty/events/protocol.lua
+++ b/lualib/resty/events/protocol.lua
@@ -47,7 +47,6 @@ local function send_frame(self, payload)
 end
 
 local _Server = {
-    _VERSION = "0.1.0",
     is_closed = is_closed,
     is_timeout = is_timeout,
     recv_frame = recv_frame,
@@ -91,7 +90,6 @@ end
 
 
 local _Client = {
-    _VERSION = "0.1.0",
     is_closed = is_closed,
     is_timeout = is_timeout,
     recv_frame = recv_frame,

--- a/lualib/resty/events/worker.lua
+++ b/lualib/resty/events/worker.lua
@@ -53,9 +53,7 @@ local PAYLOAD_T = {
 --local _worker_pid = ngx.worker.pid()
 local _worker_id = ngx.worker.id() or -1
 
-local _M = {
-    _VERSION = '0.2.0',
-}
+local _M = {}
 local _MT = { __index = _M, }
 
 -- gen a random number [0.01, 0.05]

--- a/src/ngx_lua_events_module.c
+++ b/src/ngx_lua_events_module.c
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2022 Kong Inc.
+ * Copyright 2019-2024 Kong Inc.
 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,4 +89,3 @@ ngx_lua_ffi_disable_listening_unix_socket(ngx_str_t *sock_name)
 
 #endif
 }
-


### PR DESCRIPTION
### Summary

- fix(tests): fix tests to not be order dependent on multi-worker scenario (#46)
- chore(callback): remove unnecessary assert when the type is already checked (#50)
- chore(queue): rename DEFAULT_QUEUE_LEN to more meaningful MAX_QUEUE_PREALLOCATE (#52)
- chore(callback): split get_callback_list to two functions to avoid unnecessary table creation (#51)
- fix(worker): do not premature kill threads when not exiting (#47)
- fix(broker): do not premature kill threads when not exiting (#48)
- fix(worker): separate communication and event processing to different timers (#53) - caused by #47