### PR TITLE
style(lib/compat): update module version

### DIFF
--- a/lualib/resty/events/compat/init.lua
+++ b/lualib/resty/events/compat/init.lua
@@ -1,4 +1,5 @@
 -- compatible with lua-resty-worker-events 1.0.0
+local events = require("resty.events")
 
 local ev
 
@@ -14,7 +15,7 @@ local handlers = {}
 local _configured
 
 local _M = {
-    _VERSION = "0.1.0",
+    _VERSION = events._VERSION,
 }
 
 function _M.poll()
@@ -26,7 +27,7 @@ function _M.poll()
 end
 
 function _M.configure(opts)
-    ev = require("resty.events").new(opts)
+    ev = events.new(opts)
 
     local ok, err = ev:init_worker()
     if not ok then


### PR DESCRIPTION
Since this PR (https://github.com/Kong/lua-resty-healthcheck/pull/161),
lua-resty-healthcheck can support version 0.2.x, so we should bump the version of compat module.