### PR TITLE
feat(*): worker id based queues and robustness

### DIFF
--- a/lualib/resty/events/broker.lua
+++ b/lualib/resty/events/broker.lua
@@ -1,5 +1,4 @@
 local cjson = require "cjson.safe"
-local nkeys = require "table.nkeys"
 local codec = require "resty.events.codec"
 local lrucache = require "resty.lrucache"
 local queue = require "resty.events.queue"
@@ -7,90 +6,97 @@ local server = require("resty.events.protocol").server
 local is_timeout = server.is_timeout
 local is_closed = server.is_closed
 
-local pairs = pairs
+
 local setmetatable = setmetatable
 local random = math.random
+local assert = assert
+
 
 local ngx = ngx
 local log = ngx.log
 local exit = ngx.exit
 local exiting = ngx.worker.exiting
+local worker_count = ngx.worker.count
 local ERR = ngx.ERR
 local DEBUG = ngx.DEBUG
+
 
 local spawn = ngx.thread.spawn
 local kill = ngx.thread.kill
 local wait = ngx.thread.wait
 
-local decode = codec.decode
 
+local decode = codec.decode
 local cjson_encode = cjson.encode
+
 
 local MAX_UNIQUE_EVENTS = 1024
 local WEAK_KEYS_MT = { __mode = "k", }
+
 
 local function terminating(self, worker_connection)
     return not self._clients[worker_connection] or exiting()
 end
 
+
 -- broadcast to all/unique workers
 local function broadcast_events(self, unique, data)
     local n = 0
 
-    -- if unique, schedule to a random worker
-    local idx = unique and random(1, nkeys(self._clients))
+    local workers = self._workers
 
-    for _, q in pairs(self._clients) do
+    local first_worker_id = self._first_worker_id
+    local last_worker_id = self._last_worker_id
 
-        -- skip some and broadcast to one workers
-        if unique then
-            idx = idx - 1
-
-            if idx > 0 then
-                goto continue
-            end
-        end
-
+    if unique then
+        -- if unique, schedule to a random worker
+        local worker_id = random(first_worker_id, last_worker_id)
+        local q = workers[worker_id]
         local ok, err = q:push(data)
-
         if not ok then
             log(ERR, "failed to publish event: ", err, ". ",
                      "data is :", cjson_encode(decode(data)))
-
-        else
-            n = n + 1
-
-            if unique then
-                break
-            end
         end
 
-        ::continue::
-    end  -- for q in pairs(_clients)
+        n = n + 1
+
+    else
+        for worker_id = first_worker_id, last_worker_id do
+            local q = workers[worker_id]
+            local ok, err = q:push(data)
+            if not ok then
+                log(ERR, "failed to publish event: ", err, ". ",
+                         "data is :", cjson_encode(decode(data)))
+            end
+
+            n = n + 1
+        end
+    end
 
     log(DEBUG, "event published to ", n, " workers")
 end
 
+
 local function read_thread(self, worker_connection)
     while not terminating(self, worker_connection) do
-        local data, err = worker_connection:recv_frame()
+        local event_data, err = worker_connection:recv_frame()
         if err then
             if not is_timeout(err) then
-                return nil, "failed to read event from worker: " .. err
+                return nil, err
             end
 
             -- timeout
             goto continue
         end
 
-        if not data then
+        if not event_data then
             if not exiting() then
                 log(ERR, "did not receive event from worker")
             end
             goto continue
         end
 
-        local event_data, err = decode(data)
+        event_data, err = decode(event_data)
         if not event_data then
             if not exiting() then
                 log(ERR, "failed to decode event data: ", err)
@@ -118,10 +124,11 @@ local function read_thread(self, worker_connection)
     return true
 end
 
-local function write_thread(self, worker_connection)
+
+local function write_thread(self, worker_connection, q)
     while not terminating(self, worker_connection) do
-        local payload, err = self._clients[worker_connection]:pop()
-        if not payload then
+        local data, err = q:pop()
+        if not data then
             if not is_timeout(err) then
                 return nil, "semaphore wait error: " .. err
             end
@@ -129,8 +136,13 @@ local function write_thread(self, worker_connection)
             goto continue
         end
 
-        local _, err = worker_connection:send_frame(payload)
+        local _, err = worker_connection:send_frame(data)
         if err then
+            local ok, push_err = q:push_front(data)
+            if not ok then
+                log(ERR, "failed to retain event: ", push_err, ". ",
+                         "data is :", cjson_encode(decode(data)))
+            end
             return nil, "failed to send event: " .. err
         end
 
@@ -140,18 +152,12 @@ local function write_thread(self, worker_connection)
     return true
 end
 
-local _M = {}
-local _MT = { __index = _M, }
 
-function _M.new(opts)
-    return setmetatable({
-        _opts = opts,
-        _uniques = nil,
-        _clients = nil,
-    }, _MT)
-end
+local _MT = {}
+_MT.__index = _MT
 
-function _M:init()
+
+function _MT:init()
     assert(self._opts)
 
     local _uniques, err = lrucache.new(MAX_UNIQUE_EVENTS)
@@ -159,27 +165,60 @@ function _M:init()
         return nil, "failed to create the events cache: " .. (err or "unknown")
     end
 
+    local workers = {}
+    local first_worker_id = 0 -- worker ids are zero based
+    local last_worker_id = worker_count() - 1
+    for i = first_worker_id, last_worker_id do
+        workers[i] = queue.new(self._opts.max_queue_len)
+    end
+
     self._uniques = _uniques
     self._clients = setmetatable({}, WEAK_KEYS_MT)
+    self._workers = workers
+    self._first_worker_id = first_worker_id
+    self._last_worker_id = last_worker_id
 
     return true
 end
 
-function _M:run()
+
+function _MT:run()
     local worker_connection, err = server.new()
     if not worker_connection then
         log(ERR, "failed to init socket: ", err)
         exit(444)
     end
 
-    self._clients[worker_connection] = queue.new(self._opts.max_queue_len)
+    local clients = self._clients
+    local workers = self._workers
+    local worker_id = worker_connection.info.id
+    if worker_id == -1 and not workers[-1] then
+        -- TODO: init level detection of privileged agent
+        -- Queue for the privileged agent is dynamically
+        -- created because it is not always enabled
+        -- or does not always connect to broker.
+        -- This also means that privileged agent may
+        -- miss some events on a startup.
+        workers[-1] = queue.new(self._opts.max_queue_len)
+        self._first_worker_id = -1
+    end
+
+    clients[worker_connection] = true
 
     local read_thread_co = spawn(read_thread, self, worker_connection)
-    local write_thread_co = spawn(write_thread, self, worker_connection)
+    local write_thread_co = spawn(write_thread, self, worker_connection, workers[worker_id])
+
+    if worker_id == -1 then
+        log(DEBUG, "privileged agent connected to events broker (worker pid: ",
+                   worker_connection.info.pid, ")")
+    else
+        log(DEBUG, "worker #", worker_id, " connected to events broker (worker pid: ",
+                   worker_connection.info.pid, ")")
+    end
 
     local ok, err, perr = wait(read_thread_co, write_thread_co)
 
-    self._clients[worker_connection] = nil
+    clients[worker_connection] = nil
 
     if exiting() then
         kill(read_thread_co)
@@ -188,12 +227,12 @@ function _M:run()
     end
 
     if not ok and not is_closed(err) then
-        log(ERR, "event broker failed: ", err)
+        log(ERR, "event broker failed (", err, ")")
         return exit(ngx.ERROR)
     end
 
     if perr and not is_closed(perr) then
-        log(ERR, "event broker failed: ", perr)
+        log(ERR, "event broker failed (", perr, ")")
         return exit(ngx.ERROR)
     end
 
@@ -202,5 +241,21 @@ function _M:run()
 
     return exit(ngx.OK)
 end
+
+
+local _M = {}
+
+
+function _M.new(opts)
+    local self = setmetatable({
+        _opts = opts,
+        _uniques = nil,
+        _clients = nil,
+        _workers = nil,
+    }, _MT)
+
+    return self
+end
+
 
 return _M

--- a/lualib/resty/events/codec.lua
+++ b/lualib/resty/events/codec.lua
@@ -7,9 +7,10 @@ end
 
 
 local options = {
-  dict = { "spec", "data",
-           "source", "event", "wid", "unique",
-         },
+  dict = {
+    "spec", "data",
+    "source", "event", "wid", "unique",
+  },
 }
 
 

--- a/lualib/resty/events/compat/init.lua
+++ b/lualib/resty/events/compat/init.lua
@@ -1,7 +1,9 @@
 -- compatible with lua-resty-worker-events 1.0.0
 local events = require("resty.events")
 
+
 local ev
+
 
 local ipairs = ipairs
 local ngx = ngx
@@ -9,14 +11,18 @@ local log = ngx.log
 local DEBUG = ngx.DEBUG
 local sleep = ngx.sleep
 
+
 -- store id for unsubscribe
 local handlers = {}
 
+
 local _configured
+
 
 local _M = {
     _VERSION = events._VERSION,
 }
+
 
 function _M.poll()
     sleep(0.002) -- wait events sync by unix socket connect
@@ -25,6 +31,7 @@ function _M.poll()
 
     return "done"
 end
+
 
 function _M.configure(opts)
     ev = events.new(opts)
@@ -39,15 +46,18 @@ function _M.configure(opts)
     return true
 end
 
+
 function _M.configured()
     return _configured
 end
+
 
 function _M.run()
     return ev:run()
 end
 
-_M.post = function(source, event, data, unique)
+
+function _M.post(source, event, data, unique)
     local ok, err = ev:publish(unique or "all", source, event, data)
     if not ok then
         return nil, err
@@ -56,7 +66,8 @@ _M.post = function(source, event, data, unique)
     return "done"
 end
 
-_M.post_local = function(source, event, data)
+
+function _M.post_local(source, event, data)
     local ok, err = ev:publish("current", source, event, data)
     if not ok then
         return nil, err
@@ -65,17 +76,18 @@ _M.post_local = function(source, event, data)
     return "done"
 end
 
-_M.register = function(callback, source, event, ...)
+
+function _M.register(callback, source, event, ...)
     local events = {event or "*", ...}
     for _, e in ipairs(events) do
         local id = ev:subscribe(source or "*", e or "*", callback)
         handlers[callback] = id
     end
 end
-
 _M.register_weak = _M.register
 
-_M.unregister = function(callback)
+
+function _M.unregister(callback)
     local id = handlers[callback]
     if not id then
         return
@@ -85,5 +97,6 @@ _M.unregister = function(callback)
 
     return ev:unsubscribe(id)
 end
+
 
 return _M

--- a/lualib/resty/events/disable_listening.lua
+++ b/lualib/resty/events/disable_listening.lua
@@ -3,13 +3,17 @@ require "resty.core.base" -- for ngx_str_t
 local ffi = require "ffi"
 local C = ffi.C
 
+
 local NGX_OK = ngx.OK
+
 
 ffi.cdef[[
     int ngx_lua_ffi_disable_listening_unix_socket(ngx_str_t *sock_name);
 ]]
 
+
 local sock_name_str = ffi.new("ngx_str_t[1]")
+
 
 return function(sock_name)
     sock_name_str[0].data = sock_name
@@ -23,4 +27,3 @@ return function(sock_name)
 
     return true
 end
-

--- a/lualib/resty/events/frame.lua
+++ b/lualib/resty/events/frame.lua
@@ -10,16 +10,12 @@ local rshift = bit.rshift
 
 
 local type = type
+local error = error
 local assert = assert
 local tostring = tostring
 
 
-local _M = {}
-
-
 -- frame format: Len(3 bytes) + Payload(max to 2^24 - 1 bytes)
-
-
 local UINT_HEADER_LEN = 3
 local MAX_PAYLOAD_LEN = 2^24 - 1    -- 16MB
 
@@ -48,6 +44,26 @@ local function bytes_to_uint(str)
 end
 
 
+local function validate(payload)
+    if type(payload) ~= "string" then
+        return nil, "payload must be string"
+    end
+
+    local payload_len = #payload
+
+    if payload_len > MAX_PAYLOAD_LEN then
+        return nil, "payload too big"
+    end
+
+    return payload_len
+end
+
+
+local _M = {
+    validate = validate,
+}
+
+
 function _M.recv(sock)
     local data, err = sock:receive(UINT_HEADER_LEN)
     if not data then
@@ -63,22 +79,6 @@ function _M.recv(sock)
 
     return data
 end
-
-
-local function validate(payload)
-    if type(payload) ~= "string" then
-        return nil, "payload must be string"
-    end
-
-    local payload_len = #payload
-
-    if payload_len > MAX_PAYLOAD_LEN then
-        return nil, "payload too big"
-    end
-
-    return payload_len
-end
-_M.validate = validate
 
 
 function _M.send(sock, payload)

--- a/lualib/resty/events/init.lua
+++ b/lualib/resty/events/init.lua
@@ -1,106 +1,27 @@
 local events_broker = require "resty.events.broker"
 local events_worker = require "resty.events.worker"
 
+
 local disable_listening = require "resty.events.disable_listening"
+
 
 local ngx = ngx
 local ngx_worker_id = ngx.worker.id
+local ngx_worker_count = ngx.worker.count
+
 
 local type = type
+local assert = assert
 local setmetatable = setmetatable
 local str_sub = string.sub
 
-local worker_count = ngx.worker.count()
 
-local _M = {
-    _VERSION = "0.2.1",
-}
-local _MT = { __index = _M, }
+local _MT = {}
+_MT.__index = _MT
 
-local function check_options(opts)
-    assert(type(opts) == "table", "Expected a table, got " .. type(opts))
-
-    local UNIX_PREFIX = "unix:"
-    local DEFAULT_UNIQUE_TIMEOUT = 5
-    local DEFAULT_MAX_QUEUE_LEN = 1024 * 10
-    local DEFAULT_MAX_PAYLOAD_LEN = 1024 * 64       -- 64KB
-    local LIMIT_MAX_PAYLOAD_LEN = 1024 * 1024 * 16  -- 16MB
-
-    opts.broker_id = opts.broker_id or 0
-
-    if type(opts.broker_id) ~= "number" then
-        return nil, '"worker_id" option must be a number'
-    end
-
-    if opts.broker_id < 0 or opts.broker_id >= worker_count then
-        return nil, '"worker_id" option is invalid'
-    end
-
-    if not opts.listening then
-        return nil, '"listening" option required to start'
-    end
-
-    if type(opts.listening) ~= "string" then
-        return nil, '"listening" option must be a string'
-    end
-
-    if str_sub(opts.listening, 1, #UNIX_PREFIX) ~= UNIX_PREFIX then
-        return nil, '"listening" option must start with ' .. UNIX_PREFIX
-    end
-
-    opts.unique_timeout = opts.unique_timeout or DEFAULT_UNIQUE_TIMEOUT
-
-    if type(opts.unique_timeout) ~= "number" then
-        return nil, 'optional "unique_timeout" option must be a number'
-    end
-
-    if opts.unique_timeout <= 0 then
-        return nil, '"unique_timeout" must be greater than 0'
-    end
-
-    opts.max_queue_len = opts.max_queue_len or DEFAULT_MAX_QUEUE_LEN
-
-    if type(opts.max_queue_len) ~= "number" then
-        return nil, '"max_queue_len" option must be a number'
-    end
-
-    if opts.max_queue_len <= 0 then
-        return nil, '"max_queue_len" option is invalid'
-    end
-
-    opts.max_payload_len = opts.max_payload_len or DEFAULT_MAX_PAYLOAD_LEN
-
-    if type(opts.max_payload_len) ~= "number" then
-        return nil, '"max_payload_len" option must be a number'
-    end
-
-    if opts.max_payload_len <= 0 or opts.max_payload_len > LIMIT_MAX_PAYLOAD_LEN then
-        return nil, '"max_payload_len" option is invalid'
-    end
-
-    opts.testing = opts.testing or false
-
-    if type(opts.testing) ~= "boolean" then
-        return nil, '"testing" option must be a boolean'
-    end
-
-    return true
-end
-
-function _M.new(opts)
-    assert(check_options(opts))
-
-    local self = {
-        opts   = opts,
-        broker = events_broker.new(opts),
-        worker = events_worker.new(opts),
-    }
-
-    return setmetatable(self, _MT)
-end
 
 -- opts = {broker_id = n, listening = 'unix:...', unique_timeout = x,}
-function _M:init_worker()
+function _MT:init_worker()
     local opts = self.opts
 
     local worker_id = ngx_worker_id() or -1
@@ -109,17 +30,11 @@ function _M:init_worker()
                       opts.testing   == true
 
     local ok, err
-
-    -- only enable listening on special worker id
-    if is_broker then
+    if is_broker then -- only enable listening on special worker id
         ok, err = self.broker:init()
-
-    -- disable listening in other worker
-    elseif worker_id >= 0 then
+    elseif worker_id >= 0 then -- disable listening in other worker
         ok, err = disable_listening(opts.listening)
-
-    -- we do nothing in privileged worker
-    else
+    else -- we do nothing in privileged worker
         ok = true
     end
 
@@ -135,24 +50,109 @@ function _M:init_worker()
     return true
 end
 
-function _M:run()
+
+function _MT:run()
     return self.broker:run()
 end
 
-function _M:publish(target, source, event, data)
+
+function _MT:publish(target, source, event, data)
     return self.worker:publish(target, source, event, data)
 end
 
-function _M:subscribe(source, event, callback)
+
+function _MT:subscribe(source, event, callback)
     return self.worker:subscribe(source, event, callback)
 end
 
-function _M:unsubscribe(id)
+
+function _MT:unsubscribe(id)
     return self.worker:unsubscribe(id)
 end
 
-function _M:is_ready()
+
+function _MT:is_ready()
     return self.worker:is_ready()
 end
+
+
+local function check_options(opts)
+    assert(type(opts) == "table", "Expected a table, got " .. type(opts))
+
+    local WORKER_COUNT = ngx_worker_count()
+    local UNIX_PREFIX = "unix:"
+    local DEFAULT_UNIQUE_TIMEOUT = 5
+    local DEFAULT_MAX_QUEUE_LEN = 1024 * 10
+    local DEFAULT_MAX_PAYLOAD_LEN = 1024 * 64       -- 64KB
+    local LIMIT_MAX_PAYLOAD_LEN = 1024 * 1024 * 16  -- 16MB
+
+    opts.broker_id = opts.broker_id or 0
+    if type(opts.broker_id) ~= "number" then
+        return nil, '"broker_id" option must be a number'
+    end
+    if opts.broker_id < 0 or opts.broker_id >= WORKER_COUNT then
+        return nil, '"broker_id" option is invalid'
+    end
+
+    if not opts.listening then
+        return nil, '"listening" option required to start'
+    end
+    if type(opts.listening) ~= "string" then
+        return nil, '"listening" option must be a string'
+    end
+    if str_sub(opts.listening, 1, #UNIX_PREFIX) ~= UNIX_PREFIX then
+        return nil, '"listening" option must start with ' .. UNIX_PREFIX
+    end
+
+    opts.unique_timeout = opts.unique_timeout or DEFAULT_UNIQUE_TIMEOUT
+    if type(opts.unique_timeout) ~= "number" then
+        return nil, 'optional "unique_timeout" option must be a number'
+    end
+    if opts.unique_timeout <= 0 then
+        return nil, '"unique_timeout" must be greater than 0'
+    end
+
+    opts.max_queue_len = opts.max_queue_len or DEFAULT_MAX_QUEUE_LEN
+    if type(opts.max_queue_len) ~= "number" then
+        return nil, '"max_queue_len" option must be a number'
+    end
+    if opts.max_queue_len <= 0 then
+        return nil, '"max_queue_len" option is invalid'
+    end
+
+    opts.max_payload_len = opts.max_payload_len or DEFAULT_MAX_PAYLOAD_LEN
+    if type(opts.max_payload_len) ~= "number" then
+        return nil, '"max_payload_len" option must be a number'
+    end
+    if opts.max_payload_len <= 0 or opts.max_payload_len > LIMIT_MAX_PAYLOAD_LEN then
+        return nil, '"max_payload_len" option is invalid'
+    end
+
+    opts.testing = opts.testing or false
+    if type(opts.testing) ~= "boolean" then
+        return nil, '"testing" option must be a boolean'
+    end
+
+    return true
+end
+
+
+local _M = {
+    _VERSION = "0.2.1",
+}
+
+
+function _M.new(opts)
+    assert(check_options(opts))
+
+    local self = setmetatable({
+        opts   = opts,
+        broker = events_broker.new(opts),
+        worker = events_worker.new(opts),
+    }, _MT)
+
+    return self
+end
+
 
 return _M

--- a/t/disable-listening.t
+++ b/t/disable-listening.t
@@ -121,6 +121,7 @@ unix ok #1
 [alert]
 
 
+
 === TEST 3: disable unix domain socket with wrong name
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";

--- a/t/events.t
+++ b/t/events.t
@@ -322,7 +322,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
     location = /test {
         content_by_lua_block {
             local function trim(str)
-                return string.sub(str, #"lualib/resty/events/init.lua:62: " + 1)
+                return string.sub(str, #"lualib/resty/events/init.lua:146: " + 1)
             end
 
             local ev = require("resty.events")
@@ -383,9 +383,9 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 --- request
 GET /test
 --- response_body
-"worker_id" option must be a number
-"worker_id" option is invalid
-"worker_id" option is invalid
+"broker_id" option must be a number
+"broker_id" option is invalid
+"broker_id" option is invalid
 "listening" option required to start
 "listening" option must be a string
 "listening" option must start with unix:

--- a/t/protocol.t
+++ b/t/protocol.t
@@ -95,6 +95,7 @@ cli recv len: 5
 [alert]
 
 
+
 === TEST 2: client checks unix prefix
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";

--- a/t/protocol.t
+++ b/t/protocol.t
@@ -7,7 +7,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 9) - 6;
+plan tests => repeat_each() * (blocks() * 9) - 4;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
@@ -33,6 +33,7 @@ __DATA__
                 end
 
                 ngx.log(ngx.DEBUG, "Upgrade: ", ngx.var.http_upgrade)
+                ngx.log(ngx.DEBUG, "Worker ID: ", conn.info.id)
 
                 local data, err = conn:recv_frame()
                 if not data or err then
@@ -84,6 +85,7 @@ GET /test
 world
 --- error_log
 Upgrade: Kong-Worker-Events/1
+Worker ID: 0
 srv recv data: hello
 srv send data: world
 cli recv len: 5
@@ -122,5 +124,3 @@ addr is nginx.sock
 [error]
 [crit]
 [alert]
-
-

--- a/t/stream-protocol.t
+++ b/t/stream-protocol.t
@@ -7,7 +7,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 9) - 8;
+plan tests => repeat_each() * (blocks() * 9) - 4;
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
@@ -32,6 +32,7 @@ __DATA__
                     return
                 end
 
+                ngx.log(ngx.DEBUG, "Worker ID: ", conn.info.id)
                 ngx.log(ngx.DEBUG, "stream connect ok")
 
                 local data, err = conn:recv_frame()
@@ -106,6 +107,8 @@ GET /test
 --- response_body
 world
 --- error_log
+Worker ID: 0
+stream connect ok
 srv recv data: hello
 srv send data: world
 cli recv len: 5
@@ -168,5 +171,3 @@ addr is nginx.sock
 [error]
 [crit]
 [alert]
-
-

--- a/t/stream-protocol.t
+++ b/t/stream-protocol.t
@@ -118,6 +118,7 @@ cli recv len: 5
 [alert]
 
 
+
 === TEST 2: client checks unix prefix
 --- main_config
     stream {


### PR DESCRIPTION
### Summary

1. switches from worker connection based broker queues to worker id based broker queues:
   - makes it possible to retain events even when worker has not yet connected (startup),
     or worker is restarting/reloading.
2. retains events that fail to sent to broker from worker (possible because of connection lost)
3. retains events that fail to sent to worker from broker (possible because of connection lost)
4. worker actively closes socket connection on errors
5. refactors the metatable logic so that instance methods are not in returned base class
6. tries not to call functions on module level
7. unifies style
8. fixes error message with options: `worker_id` -> `broker_id`

Fixes #42

FTI-6008, KAG-4735