### PR TITLE
tests(*): use resty.events.new correctly as documented

### DIFF
--- a/t/broadcast.t
+++ b/t/broadcast.t
@@ -22,7 +22,7 @@ __DATA__
 === TEST 1: posting events and handling events, broadcast
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             broker_id = 3,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -33,6 +33,10 @@ __DATA__
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -95,7 +99,7 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+$/
 === TEST 2: posting events and handling events, local
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             broker_id = 3,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -106,6 +110,10 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+$/
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -180,7 +188,7 @@ worker-events: handling event; source=content_by_lua, event=request3, wid=\d+$/
 === TEST 3: worker.events 'one' being done, and only once
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             unique_timeout = 0.04,
             --broker_id = 0,
@@ -192,6 +200,10 @@ worker-events: handling event; source=content_by_lua, event=request3, wid=\d+$/
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)

--- a/t/codec.t
+++ b/t/codec.t
@@ -52,6 +52,3 @@ booleantrue
 [error]
 [crit]
 [alert]
-
-
-

--- a/t/deadlock.t
+++ b/t/deadlock.t
@@ -17,8 +17,6 @@ __DATA__
     lua_shared_dict dict 1m;
     init_by_lua_block {
         require("ngx.process").enable_privileged_agent(4096)
-    }
-    init_worker_by_lua_block {
         local opts = {
             broker_id = 2,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -29,6 +27,10 @@ __DATA__
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)

--- a/t/disable-listening.t
+++ b/t/disable-listening.t
@@ -121,6 +121,7 @@ unix ok #1
 [alert]
 
 
+
 === TEST 3: disable unix domain socket with wrong name
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";

--- a/t/events-compat.t
+++ b/t/events-compat.t
@@ -22,13 +22,18 @@ __DATA__
 === TEST 1: posting events and handling events, broadcast and local
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
+    init_by_lua_block {
+        local ev = require "resty.events.compat"
+        _G.ev = ev
+    }
     init_worker_by_lua_block {
+        local ev = _G.ev
+
         local opts = {
             --broker_id = 0,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
         }
 
-        local ev = require "resty.events.compat"
         local ok, err = ev.configure(opts)
         if not ok then
             ngx.log(ngx.ERR, "failed to configure events: ", err)
@@ -38,7 +43,7 @@ __DATA__
 
         ev.register(function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", data=", data)
+                               ", data=", data)
                 end)
     }
 
@@ -86,13 +91,18 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 === TEST 2: worker.events handling remote events
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
+    init_by_lua_block {
+        local ev = require "resty.events.compat"
+        _G.ev = ev
+    }
     init_worker_by_lua_block {
+        local ev = _G.ev
+
         local opts = {
             --broker_id = 0,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
         }
 
-        local ev = require "resty.events.compat"
         local ok, err = ev.configure(opts)
         if not ok then
             ngx.log(ngx.ERR, "failed to configure events: ", err)
@@ -102,7 +112,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 
         ev.register(function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", data=", tostring(data))
+                               ", data=", tostring(data))
                 end)
     }
 
@@ -150,7 +160,13 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 === TEST 3: worker.events 'one' being done, and only once
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
+    init_by_lua_block {
+        local ev = require "resty.events.compat"
+        _G.ev = ev
+    }
     init_worker_by_lua_block {
+        local ev = _G.ev
+
         local opts = {
             unique_timeout = 0.04,
             --broker_id = 0,
@@ -167,7 +183,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 
         ev.register(function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", data=", tostring(data))
+                               ", data=", tostring(data))
                 end)
     }
 

--- a/t/events.t
+++ b/t/events.t
@@ -22,7 +22,7 @@ __DATA__
 === TEST 1: posting events and handling events, broadcast and local
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             --broker_id = 0,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -33,6 +33,10 @@ __DATA__
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -42,7 +46,7 @@ __DATA__
 
         ev:subscribe("*", "*", function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", data=", data)
+                               ", data=", data)
                 end)
 
         _G.ev = ev
@@ -94,7 +98,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 === TEST 2: worker.events handling remote events
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             --broker_id = 0,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -105,6 +109,10 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -114,7 +122,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 
         ev:subscribe("*", "*", function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", data=", tostring(data))
+                               ", data=", tostring(data))
                 end)
 
         _G.ev = ev
@@ -166,7 +174,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 === TEST 3: worker.events 'one' being done, and only once
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             unique_timeout = 0.04,
             --broker_id = 0,
@@ -178,6 +186,10 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -187,7 +199,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 
         ev:subscribe("*", "*", function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", data=", tostring(data))
+                               ", data=", tostring(data))
                 end)
 
         _G.ev = ev
@@ -248,7 +260,7 @@ worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, d
 === TEST 4: publish events at anywhere
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             --broker_id = 0,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -258,6 +270,11 @@ worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, d
         if not ev then
             ngx.log(ngx.ERR, "failed to new events")
         end
+
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
 
         ev:publish("all", "content_by_lua", "request1", "01234567890")
 
@@ -272,7 +289,7 @@ worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, d
 
         ev:subscribe("*", "*", function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", data=", tostring(data))
+                               ", data=", tostring(data))
                 end)
 
         ev:publish("all", "content_by_lua", "request3", "01234567890")
@@ -407,7 +424,7 @@ optional "unique_timeout" option must be a number
 === TEST 6: publish events exceeding 65535 bytes
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             --broker_id = 0,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -419,6 +436,10 @@ optional "unique_timeout" option must be a number
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -428,7 +449,7 @@ optional "unique_timeout" option must be a number
 
         ev:subscribe("*", "*", function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", big=", #data > 65535)
+                               ", big=", #data > 65535)
                 end)
 
         _G.ev = ev
@@ -496,7 +517,7 @@ worker-events: handler event;  source=content_by_lua, event=request4, wid=\d+, b
 === TEST 7: customize publish events limitation
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             --broker_id = 0,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -508,6 +529,10 @@ worker-events: handler event;  source=content_by_lua, event=request4, wid=\d+, b
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -517,7 +542,7 @@ worker-events: handler event;  source=content_by_lua, event=request4, wid=\d+, b
 
         ev:subscribe("*", "*", function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", data=", data)
+                               ", data=", data)
                 end)
 
         _G.ev = ev

--- a/t/listening-off.t
+++ b/t/listening-off.t
@@ -22,7 +22,7 @@ __DATA__
 === TEST 1: posting events and handling events, broadcast and local
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             --broker_id = 0,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -34,6 +34,10 @@ __DATA__
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -43,7 +47,7 @@ __DATA__
 
         ev:subscribe("*", "*", function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", data=", data)
+                               ", data=", data)
                 end)
 
         _G.ev = ev
@@ -86,7 +90,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, d
 === TEST 2: worker.events handling remote events
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             --broker_id = 0,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -98,6 +102,10 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, d
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -107,7 +115,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, d
 
         ev:subscribe("*", "*", function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", data=", tostring(data))
+                               ", data=", tostring(data))
                 end)
 
         _G.ev = ev
@@ -150,7 +158,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, d
 === TEST 3: worker.events 'one' being done, and only once
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             unique_timeout = 0.04,
             --broker_id = 0,
@@ -163,6 +171,10 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, d
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -172,7 +184,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=nil, d
 
         ev:subscribe("*", "*", function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", data=", tostring(data))
+                               ", data=", tostring(data))
                 end)
 
         _G.ev = ev
@@ -227,7 +239,7 @@ worker-events: handler event;  source=content_by_lua, event=request6, wid=nil, d
 === TEST 4: publish events at anywhere
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-    init_worker_by_lua_block {
+    init_by_lua_block {
         local opts = {
             --broker_id = 0,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -239,9 +251,14 @@ worker-events: handler event;  source=content_by_lua, event=request6, wid=nil, d
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
+
         ev:subscribe("*", "*", function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                    ", data=", tostring(data))
+                               ", data=", tostring(data))
                 end)
 
         ev:publish("all", "content_by_lua", "request1", "01234567890")

--- a/t/privileged.t
+++ b/t/privileged.t
@@ -25,8 +25,7 @@ __DATA__
     init_by_lua_block {
         local process = require "ngx.process"
         process.enable_privileged_agent(100)
-    }
-    init_worker_by_lua_block {
+
         local opts = {
             broker_id = 2,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -37,6 +36,10 @@ __DATA__
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -103,8 +106,7 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+$/
     init_by_lua_block {
         local process = require "ngx.process"
         process.enable_privileged_agent(100)
-    }
-    init_worker_by_lua_block {
+
         local opts = {
             broker_id = 2,
             listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -115,6 +117,10 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+$/
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -192,8 +198,7 @@ worker-events: handling event; source=content_by_lua, event=request3, wid=\d+$/
     init_by_lua_block {
         local process = require "ngx.process"
         process.enable_privileged_agent(100)
-    }
-    init_worker_by_lua_block {
+
         local opts = {
             unique_timeout = 0.04,
             --broker_id = 0,
@@ -205,6 +210,10 @@ worker-events: handling event; source=content_by_lua, event=request3, wid=\d+$/
             ngx.log(ngx.ERR, "failed to new events")
         end
 
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
         local ok, err = ev:init_worker()
         if not ok then
             ngx.log(ngx.ERR, "failed to init_worker events: ", err)

--- a/t/protocol.t
+++ b/t/protocol.t
@@ -93,6 +93,7 @@ cli recv len: 5
 [alert]
 
 
+
 === TEST 2: client checks unix prefix
 --- http_config
     lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
@@ -122,5 +123,3 @@ addr is nginx.sock
 [error]
 [crit]
 [alert]
-
-

--- a/t/stream-broadcast.t
+++ b/t/stream-broadcast.t
@@ -23,7 +23,7 @@ __DATA__
 --- main_config
     stream {
         lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-        init_worker_by_lua_block {
+        init_by_lua_block {
             local opts = {
                 broker_id = 3,
                 listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -34,6 +34,10 @@ __DATA__
                 ngx.log(ngx.ERR, "failed to new events")
             end
 
+            _G.ev = ev
+        }
+        init_worker_by_lua_block {
+            local ev = _G.ev
             local ok, err = ev:init_worker()
             if not ok then
                 ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -118,7 +122,7 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+$/
 --- main_config
     stream {
         lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-        init_worker_by_lua_block {
+        init_by_lua_block {
             local opts = {
                 broker_id = 3,
                 listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -129,6 +133,10 @@ worker-events: handling event; source=content_by_lua, event=request1, wid=\d+$/
                 ngx.log(ngx.ERR, "failed to new events")
             end
 
+            _G.ev = ev
+        }
+        init_worker_by_lua_block {
+            local ev = _G.ev
             local ok, err = ev:init_worker()
             if not ok then
                 ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -224,7 +232,7 @@ worker-events: handling event; source=content_by_lua, event=request3, wid=\d+$/
 --- main_config
     stream {
         lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-        init_worker_by_lua_block {
+        init_by_lua_block {
             local opts = {
                 unique_timeout = 0.04,
                 --broker_id = 0,
@@ -236,6 +244,10 @@ worker-events: handling event; source=content_by_lua, event=request3, wid=\d+$/
                 ngx.log(ngx.ERR, "failed to new events")
             end
 
+            _G.ev = ev
+        }
+        init_worker_by_lua_block {
+            local ev = _G.ev
             local ok, err = ev:init_worker()
             if not ok then
                 ngx.log(ngx.ERR, "failed to init_worker events: ", err)

--- a/t/stream-events.t
+++ b/t/stream-events.t
@@ -23,7 +23,7 @@ __DATA__
 --- main_config
     stream {
         lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-        init_worker_by_lua_block {
+        init_by_lua_block {
             local opts = {
                 --broker_id = 0,
                 listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -34,6 +34,10 @@ __DATA__
                 ngx.log(ngx.ERR, "failed to new events")
             end
 
+            _G.ev = ev
+        }
+        init_worker_by_lua_block {
+            local ev = _G.ev
             local ok, err = ev:init_worker()
             if not ok then
                 ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -41,7 +45,7 @@ __DATA__
 
             ev:subscribe("*", "*", function(data, event, source, wid)
                 ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                        ", data=", data)
+                                   ", data=", data)
                     end)
 
             _G.ev = ev
@@ -113,7 +117,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 --- main_config
     stream {
         lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-        init_worker_by_lua_block {
+        init_by_lua_block {
             local opts = {
                 --broker_id = 0,
                 listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
@@ -124,6 +128,10 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
                 ngx.log(ngx.ERR, "failed to new events")
             end
 
+            _G.ev = ev
+        }
+        init_worker_by_lua_block {
+            local ev = _G.ev
             local ok, err = ev:init_worker()
             if not ok then
                 ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -131,7 +139,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 
             ev:subscribe("*", "*", function(data, event, source, wid)
                 ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                        ", data=", tostring(data))
+                                   ", data=", tostring(data))
                     end)
 
             _G.ev = ev
@@ -204,7 +212,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 --- main_config
     stream {
         lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
-        init_worker_by_lua_block {
+        init_by_lua_block {
             local opts = {
                 unique_timeout = 0.04,
                 --broker_id = 0,
@@ -216,6 +224,10 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
                 ngx.log(ngx.ERR, "failed to new events")
             end
 
+            _G.ev = ev
+        }
+        init_worker_by_lua_block {
+            local ev = _G.ev
             local ok, err = ev:init_worker()
             if not ok then
                 ngx.log(ngx.ERR, "failed to init_worker events: ", err)
@@ -223,7 +235,7 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 
             ev:subscribe("*", "*", function(data, event, source, wid)
                 ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
-                        ", data=", tostring(data))
+                                   ", data=", tostring(data))
                     end)
 
             _G.ev = ev

--- a/t/stream-protocol.t
+++ b/t/stream-protocol.t
@@ -115,6 +115,7 @@ cli recv len: 5
 [alert]
 
 
+
 === TEST 2: client checks unix prefix
 --- main_config
     stream {
@@ -168,5 +169,3 @@ addr is nginx.sock
 [error]
 [crit]
 [alert]
-
-


### PR DESCRIPTION
### Summary

The docs say that context of `require "resty.events".new()` is `init`. The tests were calling it on `init_worker`. This commit makes tests use it in documented way.

KAG-4749