### PR TITLE
fix(*): retain events on send failures 

### DIFF
--- a/lualib/resty/events/queue.lua
+++ b/lualib/resty/events/queue.lua
@@ -44,6 +44,22 @@ function _M:push(item)
 end
 
 
+function _M:push_front(item)
+    local first = self.first
+    if first > self.last then
+        return self:push(item)
+    end
+
+    first = first - 1
+    self.first = first
+    self.elts[first] = item
+
+    self.semaphore:post()
+
+    return true
+end
+
+
 function _M:pop()
     local ok, err = self.semaphore:wait(1)
     if not ok then

--- a/lualib/resty/events/worker.lua
+++ b/lualib/resty/events/worker.lua
@@ -63,25 +63,35 @@ end
 
 local function communicate(premature, self)
     if premature then
-        return
+        return true
     end
 
     self:communicate()
+
+    return true
 end
 
 local function process_events(premature, self)
     if premature then
-        return
+        return true
     end
 
     self:process_events()
+
+    return true
 end
 
 local function start_communicate_timer(self, delay)
+    if exiting() then
+        return
+    end
     assert(timer_at(delay, communicate, self))
 end
 
 local function start_process_events_timer(self)
+    if exiting() then
+        return
+    end
     assert(timer_at(0, process_events, self))
 end
 

--- a/t/events.t
+++ b/t/events.t
@@ -290,7 +290,7 @@ worker-events: handler event;  source=content_by_lua, event=request6, wid=\d+, d
         ev:subscribe("*", "*", function(data, event, source, wid)
             ngx.log(ngx.DEBUG, "worker-events: handler event;  ", "source=",source,", event=",event, ", wid=", wid,
                                ", data=", tostring(data))
-                end)
+        end)
 
         ev:publish("all", "content_by_lua", "request3", "01234567890")
 

--- a/t/queue.t
+++ b/t/queue.t
@@ -1,0 +1,63 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use Test::Nginx::Socket::Lua;
+
+plan tests => repeat_each() * (blocks() * 5);
+
+$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+
+check_accum_error_log();
+master_on();
+workers(1);
+run_tests();
+
+__DATA__
+
+=== TEST 1: queue works correctly
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
+--- config
+    location = /test {
+        access_by_lua_block {
+            local queue = require("resty.events.queue").new(10240)
+            local value, err = queue:pop()
+            ngx.say(err)
+            assert(queue:push_front("first"))
+            ngx.say(queue:pop())
+            assert(queue:push("second"))
+            assert(queue:push_front("first"))
+            ngx.say(queue:pop())
+            ngx.say(queue:pop())
+            value, err = queue:pop()
+            ngx.say(err)
+            assert(queue:push("first"))
+            assert(queue:push("second"))
+            ngx.say(queue:pop())
+            ngx.say(queue:pop())
+            assert(queue:push_front("third"))
+            assert(queue:push_front("second"))
+            assert(queue:push_front("first"))
+            ngx.say(queue:pop())
+            ngx.say(queue:pop())
+            ngx.say(queue:pop())
+            value, err = queue:pop()
+            ngx.say(err)
+        }
+    }
+--- request
+GET /test
+--- response_body
+timeout
+first
+first
+second
+timeout
+first
+second
+first
+second
+third
+timeout
+--- no_error_log
+[crit]
+[error]
+[warn]

--- a/t/queue.t
+++ b/t/queue.t
@@ -5,8 +5,6 @@ plan tests => repeat_each() * (blocks() * 5);
 
 $ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
 
-check_accum_error_log();
-master_on();
 workers(1);
 run_tests();
 
@@ -14,33 +12,31 @@ __DATA__
 
 === TEST 1: queue works correctly
 --- http_config
-    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?.lua;;";
 --- config
     location = /test {
-        access_by_lua_block {
+        content_by_lua_block {
             local queue = require("resty.events.queue").new(10240)
             local value, err = queue:pop()
             ngx.say(err)
             assert(queue:push_front("first"))
-            ngx.say(queue:pop())
+            ngx.say((queue:pop()))
             assert(queue:push("second"))
             assert(queue:push_front("first"))
-            ngx.say(queue:pop())
-            ngx.say(queue:pop())
+            ngx.say((queue:pop()))
+            ngx.say((queue:pop()))
             value, err = queue:pop()
             ngx.say(err)
             assert(queue:push("first"))
             assert(queue:push("second"))
-            ngx.say(queue:pop())
-            ngx.say(queue:pop())
+            ngx.say((queue:pop()))
+            ngx.say((queue:pop()))
             assert(queue:push_front("third"))
             assert(queue:push_front("second"))
             assert(queue:push_front("first"))
-            ngx.say(queue:pop())
-            ngx.say(queue:pop())
-            ngx.say(queue:pop())
-            value, err = queue:pop()
-            ngx.say(err)
+            ngx.say((queue:pop()))
+            ngx.say((queue:pop()))
+            ngx.say((queue:pop()))
         }
     }
 --- request
@@ -56,7 +52,6 @@ second
 first
 second
 third
-timeout
 --- no_error_log
 [crit]
 [error]

--- a/t/retain-events.t
+++ b/t/retain-events.t
@@ -1,0 +1,85 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+use Test::Nginx::Socket::Lua;
+
+#worker_connections(1014);
+#master_process_enabled(1);
+#log_level('warn');
+
+#repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 6);
+
+$ENV{TEST_NGINX_HTML_DIR} ||= html_dir();
+
+#no_diff();
+#no_long_string();
+master_on();
+workers(1);
+run_tests();
+
+__DATA__
+
+=== TEST 1: retains events on connection failure
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;lualib/?/init.lua;lualib/?.lua;;";
+    init_by_lua_block {
+        _G.protocol = require("resty.events.protocol")
+        local opts = {
+            broker_id = 0,
+            listening = "unix:$TEST_NGINX_HTML_DIR/nginx.sock",
+        }
+
+        local ev = require("resty.events").new(opts)
+        if not ev then
+            ngx.log(ngx.ERR, "failed to new events")
+        end
+
+        _G.ev = ev
+    }
+    init_worker_by_lua_block {
+        local ev = _G.ev
+        local ok, err = ev:init_worker()
+        if not ok then
+            ngx.log(ngx.ERR, "failed to init_worker events: ", err)
+        end
+
+        ev:subscribe("*", "*", function(data, event, source, wid)
+            ngx.log(ngx.DEBUG, data)
+        end)
+    }
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock;
+        location / {
+            content_by_lua_block {
+                 _G.ev:run()
+            }
+        }
+    }
+--- config
+    location = /test {
+        content_by_lua_block {
+            local ev = _G.ev
+            ev:publish("all", "source", "event", "eventdata#1")
+            ngx.sleep(2)
+            local protocol = _G.protocol
+            local send_frame = protocol.client.send_frame
+            protocol.client.send_frame = function()
+                return nil, "lost the broker connection"
+            end
+            ev:publish("all", "source", "event", "eventdata#2")
+            ngx.sleep(0)
+            protocol.client.send_frame = send_frame
+        }
+    }
+--- request
+GET /test
+--- wait: 10
+--- error_log eval
+[
+    qr/eventdata#1/,
+    qr/event worker failed to communicate with broker \(failed to send event: lost the broker connection\)/,
+    qr/eventdata#2/,
+]
+--- no_error_log
+[crit]
+[alert]


### PR DESCRIPTION
### Summary

If there is an error with socket connection the popped event data is retained and pushed in front of the queue.