### PR TITLE
fix(*): option validation of broker id

### DIFF
--- a/lualib/resty/events/init.lua
+++ b/lualib/resty/events/init.lua
@@ -29,11 +29,11 @@ local function check_options(opts)
     opts.broker_id = opts.broker_id or 0
 
     if type(opts.broker_id) ~= "number" then
-        return nil, '"worker_id" option must be a number'
+        return nil, '"broker_id" option must be a number'
     end
 
     if opts.broker_id < 0 or opts.broker_id >= worker_count then
-        return nil, '"worker_id" option is invalid'
+        return nil, '"broker_id" option is invalid'
     end
 
     if not opts.listening then

--- a/t/events.t
+++ b/t/events.t
@@ -400,9 +400,9 @@ worker-events: handler event;  source=content_by_lua, event=request3, wid=\d+, d
 --- request
 GET /test
 --- response_body
-"worker_id" option must be a number
-"worker_id" option is invalid
-"worker_id" option is invalid
+"broker_id" option must be a number
+"broker_id" option is invalid
+"broker_id" option is invalid
 "listening" option required to start
 "listening" option must be a string
 "listening" option must start with unix:


### PR DESCRIPTION
### Summary

The option name is `broker_id` but code says that `worker_id` is invalid. This commit fixes that.