### PR TITLE
chore(worker): actively close connection to broker on error

### DIFF
--- a/lualib/resty/events/protocol.lua
+++ b/lualib/resty/events/protocol.lua
@@ -182,6 +182,20 @@ function _Client:connect(addr)
     return true
 end
 
+function _Client:close()
+    local sock = self.sock
+    if not sock then
+        return nil, "not initialized"
+    end
+
+    local ok, err = sock:close()
+    if not ok then
+        return nil, err
+    end
+
+    return true
+end
+
 return {
     server = _Server,
     client = _Client,

--- a/lualib/resty/events/worker.lua
+++ b/lualib/resty/events/worker.lua
@@ -245,6 +245,9 @@ function _M:communicate()
     local ok, err = broker_connection:connect(listening)
 
     if exiting() then
+        if ok then
+            broker_connection:close()
+        end
         return
     end
 
@@ -271,6 +274,9 @@ function _M:communicate()
     if exiting() then
         kill(read_thread_co)
         kill(write_thread_co)
+
+        broker_connection:close()
+
         return
     end
 
@@ -284,6 +290,8 @@ function _M:communicate()
 
     wait(read_thread_co)
     wait(write_thread_co)
+
+    broker_connection:close()
 
     start_communicate_timer(self, random_delay())
 end


### PR DESCRIPTION
### Summary

If worker errors for any reason, it is good to actively close connection to broker rather than waiting garbage collector to kick in and finalize it.