### PR TITLE
chore(*): release 0.3.0

### DIFF
--- a/lualib/resty/events/init.lua
+++ b/lualib/resty/events/init.lua
@@ -13,7 +13,7 @@ local str_sub = string.sub
 local worker_count = ngx.worker.count()
 
 local _M = {
-    _VERSION = "0.2.1",
+    _VERSION = "0.3.0",
 }
 local _MT = { __index = _M, }
 


### PR DESCRIPTION
### Summary

- [style(lib/compat): update module version](https://github.com/Kong/lua-resty-events/pull/57)
- [tests(*): use resty.events.new correctly as documented](https://github.com/Kong/lua-resty-events/pull/59)
- [feat(protocol): send worker info (id and pid) to broker](https://github.com/Kong/lua-resty-events/pull/54)
- [fix(*): option validation of broker id](https://github.com/Kong/lua-resty-events/pull/62)
- [fix(broker): worker id based queues](https://github.com/Kong/lua-resty-events/pull/60)
- [chore(worker): actively close connection to broker on error](https://github.com/Kong/lua-resty-events/pull/63)
- [fix(*): retain events on send failures](https://github.com/Kong/lua-resty-events/pull/61)