### PR TITLE
chore(ci): clean test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,6 @@ jobs:
       matrix:
         include:
         # TODO: arm64
-        - openresty: "1.19.9.1"
-        - openresty: "1.21.4.1"
         - openresty: "1.21.4.3"
         - openresty: "1.25.3.1"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         include:
         # TODO: arm64
+        - openresty: "1.21.4.1"
         - openresty: "1.21.4.3"
         - openresty: "1.25.3.1"
 


### PR DESCRIPTION
We will not run tests on OpenResty 1.19.9.1 and 1.21.4.1, since kong gateway are using latest version.

Restore the test of 1.214.1, or else ci will fail.

KAG-5215