### PR TITLE
chore(ci): remove openresty 1.21.4.1 in test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         include:
         # TODO: arm64
-        - openresty: "1.21.4.1"
         - openresty: "1.21.4.3"
         - openresty: "1.25.3.1"
 


### PR DESCRIPTION
KAG-5215

It is a follow up of #67.