### PR TITLE
chore(*): release 0.3.1

### DIFF
--- a/lualib/resty/events/init.lua
+++ b/lualib/resty/events/init.lua
@@ -16,7 +16,7 @@ local worker_count = utils.get_worker_count()
 
 
 local _M = {
-    _VERSION = "0.3.0",
+    _VERSION = "0.3.1",
 }
 local _MT = { __index = _M, }
 


### PR DESCRIPTION
Summary:

- [docs(readme): production ready now ](https://github.com/Kong/lua-resty-events/pull/65)
- [style(lib): style clean for logging worker info ](https://github.com/Kong/lua-resty-events/pull/66)
- [refactor(lib): add common utils](https://github.com/Kong/lua-resty-events/pulls/68)
- [feat(worker): restart event thread to avoid memory leak](https://github.com/Kong/lua-resty-events/pull/71)

KAG-5668
